### PR TITLE
Fixes for creator and engine alerts

### DIFF
--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -80,7 +80,7 @@ app.controller('createCtrl', function(
 	const onInitFail = msg => {
 		stopHeartBeat()
 		if (msg.toLowerCase() !== 'flash player required.') {
-			_alert(`Failure: ${msg}`)
+			_alert(msg, 'Failure', true, false)
 		}
 	}
 
@@ -246,14 +246,14 @@ app.controller('createCtrl', function(
 							case 'setHeight': // the height of the creator has changed
 								return setHeight(msg.data[0])
 							case 'alert':
-								return _alert(msg.data)
+								return _alert(msg.data.msg, msg.data.title, msg.data.fatal)
 							default:
 								return console.warn(`Unknown message from creator: ${msg.type}`)
 						}
 				}				
 			}
 
-			_alert(`Error, cross domain restricted for ${origin}`)
+			console.warn(`Unknown message from creator: ${origin}`)
 		}
 
 		// setup the postmessage listener
@@ -480,20 +480,11 @@ ${msg.toLowerCase()}`,
 		creator.style.height = `${h}px`
 	}
 
-	const _alert = (msg, title = null, fatal, enableLoginButton) => {
-		if (fatal == null) {
-			fatal = false
-		}
-		if (enableLoginButton == null) {
-			enableLoginButton = false
-		}
-
+	const _alert = (msg, title = 'Warning!', fatal = false, enableLoginButton = false) => {
 		$scope.alert.msg = msg
-		if (title !== null) {
-			$scope.alert.title = title
-		}
+		$scope.alert.title = title
 		$scope.alert.fatal = fatal
-
+		$scope.alert.enableLoginButton = enableLoginButton
 		Please.$apply()
 	}
 

--- a/src/js/controllers/ctrl-player.js
+++ b/src/js/controllers/ctrl-player.js
@@ -47,7 +47,7 @@ app.controller('playerCtrl', function(
 	// dom element where the widget is embedded
 	let embedTargetEl
 
-	const _alert = (msg, title = '', fatal = false) => {
+	const _alert = (msg, title = 'Warning!', fatal = false) => {
 		$scope.alert.msg = msg
 		$scope.alert.title = title
 		$scope.alert.fatal = fatal
@@ -262,7 +262,7 @@ app.controller('playerCtrl', function(
 				case 'sendPendingLogs':
 					return _sendAllPendingLogs()
 				case 'alert':
-					return _alert(msg.data, 'Warning!', false)
+					return _alert(msg.data.msg, msg.data.title, msg.fatal)
 				case 'setHeight':
 					return _setHeight(msg.data[0])
 				case 'initialize':

--- a/src/js/controllers/ctrl-player.test.js
+++ b/src/js/controllers/ctrl-player.test.js
@@ -382,7 +382,7 @@ describe('playerCtrl', () => {
 
 		// test alert post message
 		mockPlease.$apply.mockClear()
-		mockPostMessage(buildPostMessage('alert', 'aaaahh!'))
+		mockPostMessage(buildPostMessage('alert',{msg: 'aaaahh!'}))
 		expect(mockPlease.$apply).toHaveBeenCalledTimes(1)
 		expect($scope.alert.msg).toBe('aaaahh!')
 		expect($scope.alert.fatal).toBe(false)
@@ -446,7 +446,7 @@ describe('playerCtrl', () => {
 		expect(mockPlease.$apply).toHaveBeenCalledTimes(1)
 		expect($scope.alert.msg).toBe('eh2')
 		expect($scope.alert.fatal).toBe(false)
-		expect($scope.alert.title).toBe('')
+		expect($scope.alert.title).toBe('Warning!')
 	})
 
 	it('successfully throws an error with a weird post message', () => {

--- a/src/js/materia/materia.creatorcore.js
+++ b/src/js/materia/materia.creatorcore.js
@@ -79,11 +79,8 @@ Namespace('Materia').CreatorCore = (() => {
 		_sendPostMessage('start', null)
 	}
 
-	const alert = (title, msg, type) => {
-		if (type == null) {
-			type = 1
-		}
-		_sendPostMessage('alert', { title, msg, type })
+	const alert = (msg, title = null, fatal = false) => {
+		_sendPostMessage('alert', { msg, title, fatal})
 	}
 
 	const getMediaUrl = mediaId => `${_mediaUrl}/${mediaId}`

--- a/src/js/materia/materia.creatorcore.test.js
+++ b/src/js/materia/materia.creatorcore.test.js
@@ -38,8 +38,9 @@ describe('creatorcore', () => {
 			type: 'alert',
 			source: 'creator-core',
 			data: {
-				title: message,
-				type: 1
+				msg: message,
+				title: null,
+				fatal: false
 			}
 		})
 
@@ -171,9 +172,9 @@ describe('creatorcore', () => {
 	})
 
 	it('alert sends a postmessage', () => {
-		creatorCore.alert('title', 'msg', 'type')
+		creatorCore.alert('msg', 'title', 'fatal')
 		expect(parent.postMessage).toHaveBeenCalledWith(
-			'{"type":"alert","source":"creator-core","data":{"title":"title","msg":"msg","type":"type"}}',
+			'{"type":"alert","source":"creator-core","data":{"msg":"msg","title":"title","fatal":"fatal"}}',
 			'*'
 		)
 	})

--- a/src/js/materia/materia.enginecore.js
+++ b/src/js/materia/materia.enginecore.js
@@ -62,11 +62,8 @@ Namespace('Materia').Engine = (() => {
 		_sendPostMessage('addLog', { type, item_id, text, value })
 	}
 
-	const alert = (title, msg, type) => {
-		if (type == null) {
-			type = 1
-		}
-		_sendPostMessage('alert', { title, msg, type })
+	const alert = (title, msg, fatal = false) => {
+		_sendPostMessage('alert', { title, msg, fatal })
 	}
 
 	const getImageAssetUrl = mediaId => `${_mediaUrl}/${mediaId}`

--- a/src/js/materia/materia.enginecore.test.js
+++ b/src/js/materia/materia.enginecore.test.js
@@ -66,9 +66,9 @@ describe('enginecore', () => {
 	})
 
 	it('alert sends a postmessage', () => {
-		Engine.alert('title', 'msg', 'type')
+		Engine.alert('title', 'msg', 'fatal')
 		expect(parent.postMessage).toHaveBeenCalledWith(
-			'{"type":"alert","data":{"title":"title","msg":"msg","type":"type"}}',
+			'{"type":"alert","data":{"title":"title","msg":"msg","fatal":"fatal"}}',
 			'*'
 		)
 	})


### PR DESCRIPTION
Standardized alert logic in creator-core, ctrl-create, engine-core, and ctrl-player, as well as their associated tests.

All alerts use the following parameters: `{msg, title = '', fatal = false}`. Creator alerts have an optional `enableLoginButton` parameter in the creator-core. The old creator alert parameters were: `{title, msg, type}`, meaning references to those within widgets will have to be updated.