### PR TITLE
Allow widgets to scroll the page vertically.

### DIFF
--- a/src/js/controllers/ctrl-player.js
+++ b/src/js/controllers/ctrl-player.js
@@ -265,6 +265,8 @@ app.controller('playerCtrl', function(
 					return _alert(msg.data.msg, msg.data.title, msg.fatal)
 				case 'setHeight':
 					return _setHeight(msg.data[0])
+				case 'setVerticalScroll':
+					return _setVerticalScroll(msg.data[0])
 				case 'initialize':
 					break
 				default:
@@ -523,6 +525,13 @@ app.controller('playerCtrl', function(
 		let el = document.getElementsByClassName('center')[0]
 		let desiredHeight = Math.max(h, min_h)
 		el.style.height = `${desiredHeight}px`
+	}
+
+	const _setVerticalScroll = location => {
+		const containerElement = document.getElementById('container')
+		const calculatedLocation = window.scrollY + containerElement.getBoundingClientRect().y + location
+
+		window.scrollTo(0, calculatedLocation)
 	}
 
 	const _showScoreScreen = () => {

--- a/src/js/controllers/ctrl-player.js
+++ b/src/js/controllers/ctrl-player.js
@@ -529,7 +529,8 @@ app.controller('playerCtrl', function(
 
 	const _setVerticalScroll = location => {
 		const containerElement = document.getElementById('container')
-		const calculatedLocation = window.scrollY + containerElement.getBoundingClientRect().y + location
+		const calculatedLocation =
+			window.scrollY + containerElement.getBoundingClientRect().y + location
 
 		window.scrollTo(0, calculatedLocation)
 	}

--- a/src/js/controllers/ctrl-player.test.js
+++ b/src/js/controllers/ctrl-player.test.js
@@ -379,8 +379,7 @@ describe('playerCtrl', () => {
 			})
 		}
 
-		jest.spyOn(document, 'getElementById')
-			.mockReturnValueOnce(mockEmbedTargetEl)
+		jest.spyOn(document, 'getElementById').mockReturnValueOnce(mockEmbedTargetEl)
 
 		expect($window.scrollY).toBe(0)
 

--- a/src/js/controllers/ctrl-player.test.js
+++ b/src/js/controllers/ctrl-player.test.js
@@ -352,6 +352,44 @@ describe('playerCtrl', () => {
 		expect(centerStyle.height).toBe('600px')
 	})
 
+	it('successfully scrolls to a location on the page', () => {
+		let {
+			$scope,
+			controller,
+			mockCreateElement,
+			mockPostMessageFromWidget,
+			mockPostMessage,
+			mockHref,
+			embedStyle,
+			previewStyle,
+			widgetStyle,
+			centerStyle,
+			widgetInstance,
+			mockGetEl
+		} = setupDomStuff()
+
+		// mock widget start
+		mockPostMessage(buildPostMessage('start', ''))
+		_scope.$digest() // make sure defer from post message completes
+
+		//
+		let mockEmbedTargetEl = {
+			getBoundingClientRect: jest.fn().mockReturnValueOnce({
+				y: 0
+			})
+		}
+
+		jest.spyOn(document, 'getElementById')
+			.mockReturnValueOnce(mockEmbedTargetEl)
+
+		expect($window.scrollY).toBe(0)
+
+		jest.spyOn($window, 'scrollTo')
+
+		mockPostMessage(buildPostMessage('setVerticalScroll', [300]))
+		expect($window.scrollTo).toHaveBeenCalledWith(0, 300)
+	})
+
 	it('engine core alert is handled', () => {
 		let {
 			$scope,

--- a/src/js/materia/materia.enginecore.js
+++ b/src/js/materia/materia.enginecore.js
@@ -89,6 +89,10 @@ Namespace('Materia').Engine = (() => {
 		}
 	}
 
+	const setVerticalScroll = location => {
+		_sendPostMessage('setVerticalScroll', [location])
+	}
+
 	const disableResizeInterval = () => {
 		clearInterval(_resizeInterval)
 	}
@@ -105,6 +109,7 @@ Namespace('Materia').Engine = (() => {
 		sendStorage,
 		disableResizeInterval,
 		setHeight, // allows the widget to resize its iframe container to fit the height of its contents
+		setVerticalScroll, // allows the widget to scroll the page to a specific location
 		escapeScriptTags
 	}
 })()

--- a/src/js/materia/materia.enginecore.test.js
+++ b/src/js/materia/materia.enginecore.test.js
@@ -34,6 +34,7 @@ describe('enginecore', () => {
 		expect(Engine.sendStorage).toBeDefined()
 		expect(Engine.disableResizeInterval).toBeDefined()
 		expect(Engine.setHeight).toBeDefined()
+		expect(Engine.setVerticalScroll).toBeDefined()
 		expect(Engine.escapeScriptTags).toBeDefined()
 	})
 
@@ -127,6 +128,15 @@ describe('enginecore', () => {
 		let ex = JSON.stringify({
 			type: 'setHeight',
 			data: [200]
+		})
+		expect(parent.postMessage).toHaveBeenLastCalledWith(ex, '*')
+	})
+
+	it('setVerticalScroll sends message', () => {
+		Engine.setVerticalScroll(0)
+		let ex = JSON.stringify({
+			type: 'setVerticalScroll',
+			data: [0]
 		})
 		expect(parent.postMessage).toHaveBeenLastCalledWith(ex, '*')
 	})


### PR DESCRIPTION
Closes #21.

Added engine core and player controller methods to enable widgets to scroll to a vertical location.