### PR TITLE
Strip question and answer IDs from imported questions.

### DIFF
--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -500,9 +500,11 @@ ${msg.toLowerCase()}`,
 
 			//strip id from all imported questions and answers to avoid collisions
 			questions.forEach(question => {
-				question.answers.forEach(answer => {
-					answer.id = null
-				})
+				if (question.answers && question.answers.length > 0) {
+					question.answers.forEach(answer => {
+						answer.id = null
+					})
+				}
 				question.id = null
 			})
 

--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -497,6 +497,15 @@ ${msg.toLowerCase()}`,
 			}
 			// assumes questions is already a JSON string
 			questions = JSON.parse(questions)
+
+			//strip id from all imported questions and answers to avoid collisions
+			questions.forEach(question => {
+				question.answers.forEach(answer => {
+					answer.id = null
+				})
+				question.id = null
+			})
+
 			return sendToCreator('onQuestionImportComplete', [questions])
 		},
 


### PR DESCRIPTION
Closes #37.

Imported questions and all of their answers now have the 'id' properties set to null, allowing the backend to set them freshly to prevent collisions.