### PR TITLE
Adjust 'this person can edit this widget' checks on My Widgets page, locks widget instances in creator.

### DIFF
--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -158,6 +158,16 @@ app.controller('createCtrl', function(
 		}
 	}
 
+	const canPublish = () => {
+		const deferred = $q.defer()
+		widgetSrv.canBePublishedByCurrentUser(instance.id)
+		.then(canPublish => {
+			$scope.canPublish = canPublish
+			deferred.resolve()
+		})
+		return deferred.promise
+	}
+
 	// build a my-widgets url to a specific widget
 	const getMyWidgetsUrl = instid => `${BASE_URL}my-widgets#${instid}`
 
@@ -521,6 +531,7 @@ ${msg.toLowerCase()}`,
 	$scope.saveText = 'Save Draft'
 	$scope.previewText = 'Preview'
 	$scope.publishText = 'Publish...'
+	$scope.canPublish = false
 	$scope.invalid = false
 	$scope.modal = false
 	$scope.requestSave = _requestSave
@@ -545,6 +556,7 @@ ${msg.toLowerCase()}`,
 					.then(widgetSrv.getWidget)
 					.then(embed)
 					.then(initCreator)
+					.then(canPublish)
 					.then(showButtons)
 					.then(startHeartBeat)
 					.catch(onInitFail)
@@ -556,6 +568,7 @@ ${msg.toLowerCase()}`,
 			.then(widgetSrv.getWidgetInfo)
 			.then(embed)
 			.then(initCreator)
+			.then(canPublish)
 			.then(showButtons)
 			.then(startHeartBeat)
 			.catch(onInitFail)

--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -160,8 +160,7 @@ app.controller('createCtrl', function(
 
 	const canPublish = () => {
 		const deferred = $q.defer()
-		widgetSrv.canBePublishedByCurrentUser(instance.id)
-		.then(canPublish => {
+		widgetSrv.canBePublishedByCurrentUser(instance.id).then(canPublish => {
 			$scope.canPublish = canPublish
 			deferred.resolve()
 		})

--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -160,7 +160,7 @@ app.controller('createCtrl', function(
 
 	const canPublish = () => {
 		const deferred = $q.defer()
-		widgetSrv.canBePublishedByCurrentUser(instance.id).then(canPublish => {
+		widgetSrv.canBePublishedByCurrentUser(widget_id).then(canPublish => {
 			$scope.canPublish = canPublish
 			deferred.resolve()
 		})

--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -158,11 +158,15 @@ app.controller('createCtrl', function(
 		}
 	}
 
-	const canPublish = () => {
+	const canPublish = widgetData => {
 		const deferred = $q.defer()
 		widgetSrv.canBePublishedByCurrentUser(widget_id).then(canPublish => {
 			$scope.canPublish = canPublish
-			deferred.resolve()
+
+			if (!widgetData.is_draft && !canPublish)
+				deferred.reject('Widget type can not be edited by students after publishing.')
+
+			deferred.resolve(widgetData)
 		})
 		return deferred.promise
 	}
@@ -552,10 +556,11 @@ ${msg.toLowerCase()}`,
 		getQset().then(() => {
 			if (!$scope.invalid) {
 				$q(resolve => resolve(inst_id))
+					.then(widgetSrv.lockWidget)
 					.then(widgetSrv.getWidget)
+					.then(canPublish)
 					.then(embed)
 					.then(initCreator)
-					.then(canPublish)
 					.then(showButtons)
 					.then(startHeartBeat)
 					.catch(onInitFail)
@@ -565,9 +570,9 @@ ${msg.toLowerCase()}`,
 		// initialize a new creator
 		$q(resolve => resolve(widget_id))
 			.then(widgetSrv.getWidgetInfo)
+			.then(canPublish)
 			.then(embed)
 			.then(initCreator)
-			.then(canPublish)
 			.then(showButtons)
 			.then(startHeartBeat)
 			.catch(onInitFail)

--- a/src/js/controllers/ctrl-my-widgets.js
+++ b/src/js/controllers/ctrl-my-widgets.js
@@ -70,6 +70,7 @@ app.controller('MyWidgetsController', function(
 			.all([
 				userServ.get(),
 				selectedWidgetSrv.getUserPermissions(),
+				selectedWidgetSrv.getPublishPermission(),
 				selectedWidgetSrv.getDateRanges()
 			])
 			.then(data => {
@@ -80,6 +81,7 @@ app.controller('MyWidgetsController', function(
 
 				$scope.user = data[0]
 				$scope.perms = data[1]
+				$scope.canPublish = data[2]
 				populateAccess()
 
 				$timeout.cancel(loadScoresTimout)
@@ -135,6 +137,7 @@ app.controller('MyWidgetsController', function(
 		$scope.selected.shareable = false
 		$scope.selected.hasScores = false
 		$scope.perms.collaborators = []
+		$scope.canPublish = false
 
 		// TODO
 		$scope.perms.error = false
@@ -257,7 +260,10 @@ app.controller('MyWidgetsController', function(
 		guestAccess: false,
 		embeddedOnly: false
 	}
-	$scope.perms = { collaborators: [] }
+	$scope.perms = {
+		collaborators: []
+	}
+	$scope.canPublish = false
 	$scope.show = {
 		collaborationModal: false,
 		availabilityModal: false,

--- a/src/js/controllers/ctrl-my-widgets.js
+++ b/src/js/controllers/ctrl-my-widgets.js
@@ -70,7 +70,6 @@ app.controller('MyWidgetsController', function(
 			.all([
 				userServ.get(),
 				selectedWidgetSrv.getUserPermissions(),
-				selectedWidgetSrv.getPublishPermission(),
 				selectedWidgetSrv.getDateRanges()
 			])
 			.then(data => {
@@ -81,7 +80,6 @@ app.controller('MyWidgetsController', function(
 
 				$scope.user = data[0]
 				$scope.perms = data[1]
-				$scope.canPublish = data[2]
 				populateAccess()
 
 				$timeout.cancel(loadScoresTimout)
@@ -137,7 +135,6 @@ app.controller('MyWidgetsController', function(
 		$scope.selected.shareable = false
 		$scope.selected.hasScores = false
 		$scope.perms.collaborators = []
-		$scope.canPublish = false
 
 		// TODO
 		$scope.perms.error = false
@@ -263,7 +260,6 @@ app.controller('MyWidgetsController', function(
 	$scope.perms = {
 		collaborators: []
 	}
-	$scope.canPublish = false
 	$scope.show = {
 		collaborationModal: false,
 		availabilityModal: false,
@@ -272,7 +268,8 @@ app.controller('MyWidgetsController', function(
 		exportModal: false,
 		deleteDialog: false,
 		embedToggle: false,
-		editPublishedWarning: false
+		editPublishedWarning: false,
+		restrictedPublishWarning: false
 	}
 	$scope.SCORE_TAB_GRAPH = 0
 	$scope.SCORE_TAB_INDIVIDUAL = 1

--- a/src/js/controllers/ctrl-selectedwidget.js
+++ b/src/js/controllers/ctrl-selectedwidget.js
@@ -55,22 +55,22 @@ app.controller('SelectedWidgetController', function(
 	}
 
 	const _editWidgetPromise = () => {
-		return Materia.Coms.Json.send('widget_instance_edit_perms_verify', [$scope.selected.widget.id]).then(
-			response => {
-				if (response.is_locked) {
-					$scope.alert.msg =
-						'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+		return Materia.Coms.Json.send('widget_instance_edit_perms_verify', [
+			$scope.selected.widget.id
+		]).then(response => {
+			if (response.is_locked) {
+				$scope.alert.msg =
+					'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+			} else {
+				if ($scope.selected.widget.is_draft) {
+					window.location = $scope.selected.edit
 				} else {
-					if ($scope.selected.widget.is_draft) {
-						window.location = $scope.selected.edit
-					} else {
-						if (response.can_publish) $scope.show.editPublishedWarning = true
-						else $scope.show.restrictedPublishWarning = true
-					}
+					if (response.can_publish) $scope.show.editPublishedWarning = true
+					else $scope.show.restrictedPublishWarning = true
 				}
-				Please.$apply()
 			}
-		)
+			Please.$apply()
+		})
 	}
 
 	const _editWidget = () => {

--- a/src/js/controllers/ctrl-selectedwidget.js
+++ b/src/js/controllers/ctrl-selectedwidget.js
@@ -56,7 +56,7 @@ app.controller('SelectedWidgetController', function(
 
 	const _editWidget = () => {
 		if ($scope.selected.editable) {
-			Materia.Coms.Json.send('edit_verify', [$scope.selected.widget.id]).then(response => {
+			Materia.Coms.Json.send('widget_edit_perms_verify', [$scope.selected.widget.id]).then(response => {
 				if (response.is_locked) {
 					$scope.alert.msg =
 						'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'

--- a/src/js/controllers/ctrl-selectedwidget.js
+++ b/src/js/controllers/ctrl-selectedwidget.js
@@ -54,24 +54,28 @@ app.controller('SelectedWidgetController', function(
 		})
 	}
 
+	const _editWidgetPromise = () => {
+		return Materia.Coms.Json.send('widget_instance_edit_perms_verify', [$scope.selected.widget.id]).then(
+			response => {
+				if (response.is_locked) {
+					$scope.alert.msg =
+						'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+				} else {
+					if ($scope.selected.widget.is_draft) {
+						window.location = $scope.selected.edit
+					} else {
+						if (response.can_publish) $scope.show.editPublishedWarning = true
+						else $scope.show.restrictedPublishWarning = true
+					}
+				}
+				Please.$apply()
+			}
+		)
+	}
+
 	const _editWidget = () => {
 		if ($scope.selected.editable) {
-			Materia.Coms.Json.send('widget_instance_edit_perms_verify', [$scope.selected.widget.id]).then(
-				response => {
-					if (response.is_locked) {
-						$scope.alert.msg =
-							'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
-					} else {
-						if ($scope.selected.widget.is_draft) {
-							window.location = $scope.selected.edit
-						} else {
-							if (response.can_publish) $scope.show.editPublishedWarning = true
-							else $scope.show.restrictedPublishWarning = true
-						}
-					}
-					Please.$apply()
-				}
-			)
+			_editWidgetPromise()
 		}
 
 		return false
@@ -228,4 +232,11 @@ app.controller('SelectedWidgetController', function(
 	$scope.enableOlderScores = _enableOlderScores
 
 	$scope.alert = Alert
+
+	/* develblock:start */
+	// these method are exposed for testing
+	$scope.jestTest = {
+		_editWidgetPromise
+	}
+	/* develblock:end */
 })

--- a/src/js/controllers/ctrl-selectedwidget.js
+++ b/src/js/controllers/ctrl-selectedwidget.js
@@ -56,20 +56,22 @@ app.controller('SelectedWidgetController', function(
 
 	const _editWidget = () => {
 		if ($scope.selected.editable) {
-			Materia.Coms.Json.send('widget_edit_perms_verify', [$scope.selected.widget.id]).then(response => {
-				if (response.is_locked) {
-					$scope.alert.msg =
-						'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
-				} else {
-					if ($scope.selected.widget.is_draft) {
-						window.location = $scope.selected.edit
+			Materia.Coms.Json.send('widget_instance_edit_perms_verify', [$scope.selected.widget.id]).then(
+				response => {
+					if (response.is_locked) {
+						$scope.alert.msg =
+							'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
 					} else {
-						if (response.can_publish) $scope.show.editPublishedWarning = true
-						else $scope.show.restrictedPublishWarning = true
+						if ($scope.selected.widget.is_draft) {
+							window.location = $scope.selected.edit
+						} else {
+							if (response.can_publish) $scope.show.editPublishedWarning = true
+							else $scope.show.restrictedPublishWarning = true
+						}
 					}
+					Please.$apply()
 				}
-				Please.$apply()
-			})
+			)
 		}
 
 		return false

--- a/src/js/controllers/ctrl-selectedwidget.js
+++ b/src/js/controllers/ctrl-selectedwidget.js
@@ -56,16 +56,17 @@ app.controller('SelectedWidgetController', function(
 
 	const _editWidget = () => {
 		if ($scope.selected.editable) {
-			Materia.Coms.Json.send('widget_instance_lock', [$scope.selected.widget.id]).then(success => {
-				if (success) {
+			Materia.Coms.Json.send('edit_verify', [$scope.selected.widget.id]).then(response => {
+				if (response.is_locked) {
+					$scope.alert.msg =
+						'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+				} else {
 					if ($scope.selected.widget.is_draft) {
 						window.location = $scope.selected.edit
 					} else {
-						$scope.show.editPublishedWarning = true
+						if (response.can_publish) $scope.show.editPublishedWarning = true
+						else $scope.show.restrictedPublishWarning = true
 					}
-				} else {
-					$scope.alert.msg =
-						'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
 				}
 				Please.$apply()
 			})

--- a/src/js/controllers/ctrl-selectedwidget.test.js
+++ b/src/js/controllers/ctrl-selectedwidget.test.js
@@ -34,6 +34,8 @@ describe('adminWidgetController', () => {
 			$on: jest.fn()
 		}
 
+		Namespace('Materia.Coms.Json').send = sendMock = jest.fn()
+
 		var controller = $controller('SelectedWidgetController', { $scope })
 	})
 
@@ -66,5 +68,15 @@ describe('adminWidgetController', () => {
 		// this will not pass if $scope.hideModal is an arrow function
 		$scope.hideModal.bind(this)()
 		expect(this.$parent.hideModal).toHaveBeenCalled()
+	})
+
+	it('does nothing if a widget is not editable', () => {
+		$scope.selected = {
+			editable: false
+		}
+
+		$scope.editWidget()
+
+		expect(Materia.Coms.Json.send).not.toHaveBeenCalled()
 	})
 })

--- a/src/js/controllers/ctrl-selectedwidget.test.js
+++ b/src/js/controllers/ctrl-selectedwidget.test.js
@@ -95,7 +95,9 @@ describe('adminWidgetController', () => {
 
 		return $scope.jestTest._editWidgetPromise().then(() => {
 			expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_instance_edit_perms_verify', [1])
-			expect($scope.alert.msg).toBe('This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.')
+			expect($scope.alert.msg).toBe(
+				'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+			)
 		})
 	})
 })

--- a/src/js/controllers/ctrl-selectedwidget.test.js
+++ b/src/js/controllers/ctrl-selectedwidget.test.js
@@ -34,7 +34,7 @@ describe('adminWidgetController', () => {
 			$on: jest.fn()
 		}
 
-		Namespace('Materia.Coms.Json').send = sendMock = jest.fn()
+		Namespace('Materia.Coms.Json').send = jest.fn()
 
 		var controller = $controller('SelectedWidgetController', { $scope })
 	})
@@ -78,5 +78,24 @@ describe('adminWidgetController', () => {
 		$scope.editWidget()
 
 		expect(Materia.Coms.Json.send).not.toHaveBeenCalled()
+	})
+
+	it('sets an alert message if the widget is locked already', () => {
+		$scope.selected = {
+			editable: true,
+			widget: {
+				id: 1
+			}
+		}
+
+		Namespace('Materia.Coms.Json').send = jest.fn().mockResolvedValueOnce({
+			is_locked: true,
+			can_publish: true
+		})
+
+		return $scope.jestTest._editWidgetPromise().then(() => {
+			expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_instance_edit_perms_verify', [1])
+			expect($scope.alert.msg).toBe('This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.')
+		})
 	})
 })

--- a/src/js/services/srv-selectedwidget.js
+++ b/src/js/services/srv-selectedwidget.js
@@ -78,7 +78,7 @@ app.service('selectedWidgetSrv', function($rootScope, $q, OBJECT_TYPES) {
 
 	const getPublishPermission = () => {
 		const deferred = $q.defer()
-		Materia.Coms.Json.send('publish_verify', [_widget.id]).then(response => {
+		Materia.Coms.Json.send('publish_verify', [_widget.widget.id]).then(response => {
 			deferred.resolve(response)
 		})
 		return deferred.promise

--- a/src/js/services/srv-selectedwidget.js
+++ b/src/js/services/srv-selectedwidget.js
@@ -76,14 +76,6 @@ app.service('selectedWidgetSrv', function($rootScope, $q, OBJECT_TYPES) {
 		})
 	}
 
-	const getPublishPermission = () => {
-		const deferred = $q.defer()
-		Materia.Coms.Json.send('publish_verify', [_widget.widget.id]).then(response => {
-			deferred.resolve(response)
-		})
-		return deferred.promise
-	}
-
 	const getPlayLogsForSemester = (term, year) => {
 		const deferred = $q.defer()
 
@@ -226,7 +218,6 @@ app.service('selectedWidgetSrv', function($rootScope, $q, OBJECT_TYPES) {
 		getSelectedId,
 		getScoreSummaries,
 		getUserPermissions,
-		getPublishPermission,
 		getPlayLogsForSemester,
 		getDateRanges,
 		getSemesterFromTimestamp,

--- a/src/js/services/srv-selectedwidget.js
+++ b/src/js/services/srv-selectedwidget.js
@@ -78,9 +78,7 @@ app.service('selectedWidgetSrv', function($rootScope, $q, OBJECT_TYPES) {
 
 	const getPublishPermission = () => {
 		const deferred = $q.defer()
-		Materia.Coms.Json.send('publish_verify', [
-			_widget.id
-		]).then(response => {
+		Materia.Coms.Json.send('publish_verify', [_widget.id]).then(response => {
 			deferred.resolve(response)
 		})
 		return deferred.promise

--- a/src/js/services/srv-selectedwidget.js
+++ b/src/js/services/srv-selectedwidget.js
@@ -76,6 +76,16 @@ app.service('selectedWidgetSrv', function($rootScope, $q, OBJECT_TYPES) {
 		})
 	}
 
+	const getPublishPermission = () => {
+		const deferred = $q.defer()
+		Materia.Coms.Json.send('publish_verify', [
+			_widget.id
+		]).then(response => {
+			deferred.resolve(response)
+		})
+		return deferred.promise
+	}
+
 	const getPlayLogsForSemester = (term, year) => {
 		const deferred = $q.defer()
 
@@ -218,6 +228,7 @@ app.service('selectedWidgetSrv', function($rootScope, $q, OBJECT_TYPES) {
 		getSelectedId,
 		getScoreSummaries,
 		getUserPermissions,
+		getPublishPermission,
 		getPlayLogsForSemester,
 		getDateRanges,
 		getSemesterFromTimestamp,

--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -233,6 +233,15 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		}
 	}
 
+	const canBePublishedByCurrentUser = (inst_id) => {
+		const deferred = $q.defer()
+		Materia.Coms.Json.send('publish_verify', [inst_id]).then(response => {
+			deferred.resolve(response)
+		})
+
+		return deferred.promise
+	}
+
 	return {
 		getWidgets,
 		getWidgetsByType,
@@ -245,6 +254,7 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		selectWidgetFromHashUrl,
 		convertAvailibilityDates,
 		copyWidget,
-		deleteWidget
+		deleteWidget,
+		canBePublishedByCurrentUser
 	}
 })

--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -53,6 +53,20 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		return Materia.Coms.Json.send('widgets_get', [[id]]).then(widgets => widgets[0])
 	}
 
+	const lockWidget = (id = null) => {
+		const deferred = $q.defer()
+		Materia.Coms.Json.send('widget_instance_lock', [id]).then(success => {
+			if (success) {
+				deferred.resolve(id)
+			} else {
+				deferred.reject(
+					'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+				)
+			}
+		})
+		return deferred.promise
+	}
+
 	const getWidgetsByType = (type = 'featured') => {
 		return Materia.Coms.Json.send('widgets_get_by_type', [type])
 	}
@@ -247,6 +261,7 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		getWidgetsByType,
 		getWidget,
 		getWidgetInfo,
+		lockWidget,
 		sortWidgets,
 		saveWidget,
 		removeWidget,

--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -233,7 +233,7 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		}
 	}
 
-	const canBePublishedByCurrentUser = (inst_id) => {
+	const canBePublishedByCurrentUser = inst_id => {
 		const deferred = $q.defer()
 		Materia.Coms.Json.send('publish_verify', [inst_id]).then(response => {
 			deferred.resolve(response)

--- a/src/js/services/srv-widget.test.js
+++ b/src/js/services/srv-widget.test.js
@@ -63,6 +63,7 @@ describe('widgetSrv', () => {
 		expect(_service.getWidgetsByType).toBeDefined()
 		expect(_service.getWidget).toBeDefined()
 		expect(_service.getWidgetInfo).toBeDefined()
+		expect(_service.lockWidget).toBeDefined()
 		expect(_service.sortWidgets).toBeDefined()
 		expect(_service.saveWidget).toBeDefined()
 		expect(_service.removeWidget).toBeDefined()
@@ -400,5 +401,50 @@ describe('widgetSrv', () => {
 		_service.selectWidgetFromHashUrl()
 		$scope.$digest() // processes promise
 		expect(_selectedWidgetSrv.notifyAccessDenied).toHaveBeenCalled()
+	})
+
+	it('rejects with a message when a widget is already locked', () => {
+		mockSendPromiseOnce(false)
+
+		let promiseSpy = jest.fn()
+		let promiseCatch = jest.fn()
+		_service
+			.lockWidget(1)
+			.then(promiseSpy)
+			.catch(promiseCatch)
+		$scope.$digest() // processes promise
+
+		expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_instance_lock', [1])
+		expect(promiseSpy).not.toHaveBeenCalled()
+		expect(promiseCatch).toHaveBeenCalledWith('This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.')
+	})
+
+	it('locks a widget', () => {
+		mockSendPromiseOnce(true)
+
+		let promiseSpy = jest.fn()
+		let promiseCatch = jest.fn()
+		_service
+			.lockWidget(1)
+			.then(promiseSpy)
+			.catch(promiseCatch)
+		$scope.$digest() // processes promise
+
+		expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_instance_lock', [1])
+		expect(promiseSpy).toHaveBeenCalledWith(1)
+		expect(promiseCatch).not.toHaveBeenCalled()
+	})
+
+	it('checks whether a widget can be published by the current user', () => {
+		mockSendPromiseOnce(true)
+
+		let promiseSpy = jest.fn()
+		_service
+			.canBePublishedByCurrentUser(1)
+			.then(promiseSpy)
+		$scope.$digest() // processes promise
+
+		expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_publish_perms_verify', [1])
+		expect(promiseSpy).toHaveBeenCalledWith(true)
 	})
 })

--- a/src/js/services/srv-widget.test.js
+++ b/src/js/services/srv-widget.test.js
@@ -416,7 +416,9 @@ describe('widgetSrv', () => {
 
 		expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_instance_lock', [1])
 		expect(promiseSpy).not.toHaveBeenCalled()
-		expect(promiseCatch).toHaveBeenCalledWith('This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.')
+		expect(promiseCatch).toHaveBeenCalledWith(
+			'This widget is currently locked, you will be able to edit this widget when it is no longer being edited by somebody else.'
+		)
 	})
 
 	it('locks a widget', () => {
@@ -439,9 +441,7 @@ describe('widgetSrv', () => {
 		mockSendPromiseOnce(true)
 
 		let promiseSpy = jest.fn()
-		_service
-			.canBePublishedByCurrentUser(1)
-			.then(promiseSpy)
+		_service.canBePublishedByCurrentUser(1).then(promiseSpy)
 		$scope.$digest() // processes promise
 
 		expect(Materia.Coms.Json.send).toHaveBeenCalledWith('widget_publish_perms_verify', [1])


### PR DESCRIPTION
Closes #48.

Relies on #47.

Detaches the act of locking a widget instance from clicking the 'Edit Widget' button in the My Widgets page and does it in the creator instead.

Only remaining (possible) issue: If a student tries getting clever and goes straight to the create URL of a widget instance, the checks will now prevent the creator from loading - but will still lock that instance.

Either need to consider retooling how the various methods work, or create a new endpoint that can unlock a widget instance.