### PR TITLE
Creator controller checkUserPublishPerms new widget fix.

### DIFF
--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -163,7 +163,9 @@ app.controller('createCtrl', function(
 		widgetSrv.canBePublishedByCurrentUser(widget_id).then(canPublish => {
 			$scope.canPublish = canPublish
 
-			if (!widgetData.is_draft && !canPublish)
+			// if the widget is published and the current user can not publish it, then they can not edit it
+			// also make sure that this isn't the creation of a new widget - which technically is also not a draft
+			if (typeof widgetData.is_draft != 'undefined' && !widgetData.is_draft && !canPublish)
 				deferred.reject('Widget type can not be edited by students after publishing.')
 
 			deferred.resolve(widgetData)

--- a/src/js/controllers/ctrl-create.js
+++ b/src/js/controllers/ctrl-create.js
@@ -158,14 +158,20 @@ app.controller('createCtrl', function(
 		}
 	}
 
-	const checkUserPublishPerms = widgetData => {
+	const prePublishPermsCheck = widgetData => {
+		const deferred = $q.defer()
+		checkUserPublishPerms(widgetData, true).then(() => deferred.resolve(widgetData))
+		return deferred.promise
+	}
+
+	const checkUserPublishPerms = (widgetData, newInstance) => {
 		const deferred = $q.defer()
 		widgetSrv.canBePublishedByCurrentUser(widget_id).then(canPublish => {
 			$scope.canPublish = canPublish
 
 			// if the widget is published and the current user can not publish it, then they can not edit it
 			// also make sure that this isn't the creation of a new widget - which technically is also not a draft
-			if (typeof widgetData.is_draft != 'undefined' && !widgetData.is_draft && !canPublish)
+			if (!newInstance && !widgetData.is_draft && !canPublish)
 				deferred.reject('Widget type can not be edited by students after publishing.')
 
 			deferred.resolve(widgetData)
@@ -585,7 +591,7 @@ ${msg.toLowerCase()}`,
 		// initialize a new creator
 		$q(resolve => resolve(widget_id))
 			.then(widgetSrv.getWidgetInfo)
-			.then(checkUserPublishPerms)
+			.then(prePublishPermsCheck)
 			.then(embed)
 			.then(initCreator)
 			.then(showButtons)


### PR DESCRIPTION
Fixes the creator controller's check to see if a user can edit a published widget.
Was breaking when creating a new widget since `is_draft` was undefined.