### PR TITLE
#1129 lti picker doesn't handle long titles

### DIFF
--- a/src/css/my-widgets.scss
+++ b/src/css/my-widgets.scss
@@ -255,6 +255,7 @@
 		font-weight: 900;
 		font-size: 25px;
 		padding-right: 10px;
+		word-break: break-all;
 	}
 	.page .header h2 {
 		margin: 0;

--- a/src/css/util-lti-picker.scss
+++ b/src/css/util-lti-picker.scss
@@ -223,6 +223,10 @@ header > h1 {
 	bottom: 10px;
 }
 
+#list-container li .searchable {
+	word-break: break-all;
+}
+
 #list-container li .embed-button {
 	display: none;
 	position: absolute;

--- a/src/css/util-lti-picker.scss
+++ b/src/css/util-lti-picker.scss
@@ -223,17 +223,6 @@ header > h1 {
 	bottom: 10px;
 }
 
-#list-container li .view-at-materia {
-	display: none;
-	position: absolute;
-	right: 20px;
-	top: 10px;
-}
-#list-container li:hover .view-at-materia,
-#list-container li.selected .view-at-materia {
-	display: block;
-}
-
 #list-container li .embed-button {
 	display: none;
 	position: absolute;
@@ -243,6 +232,13 @@ header > h1 {
 #list-container li:hover .embed-button,
 #list-container li.selected .embed-button {
 	display: inline-block;
+
+	div {
+		display: inline-block;
+		width: 12px;
+		height: 12px;
+		background: url(../../../img/external_link_arrow_brown.png) 0% 0% no-repeat;
+	}
 }
 
 #select-widget .widget-icon {


### PR DESCRIPTION
- Remove CSS that is no longer used.
- Add CSS for the external link image

Fixes issue #1129 in Materia
Relies on Pull request #1234 in Materia