### PR TITLE
#1243 TypeError: Cannot set property 'checked' of undefined when selecting export options on widget with no scores

### DIFF
--- a/src/js/controllers/ctrl-export-scores.js
+++ b/src/js/controllers/ctrl-export-scores.js
@@ -47,8 +47,11 @@ app.controller('ExportScoresController', function(Please, $scope, selectedWidget
 				})
 			}
 
-			// First semester is checked by default
-			$scope.semesters[0].checked = true
+			// First semester is checked by default unless there are no semesters
+			if ($scope.semesters.length !== 0) {
+				$scope.semesters[0].checked = true
+			}
+
 			$scope.onSelectedSemestersChange()
 			Please.$apply()
 		})


### PR DESCRIPTION
Fixes issue #1243 on Materia.

- Add check for when the semesters object is empty.