### PR TITLE
#78 Materia.Engine does not check if received POST messages are valid

### DIFF
--- a/src/js/materia/materia.creatorcore.js
+++ b/src/js/materia/materia.creatorcore.js
@@ -6,6 +6,7 @@ Namespace('Materia').CreatorCore = (() => {
 	let _resizeInterval = null
 
 	const _onPostMessage = e => {
+		if (typeof e.data !== 'string') return
 		const msg = JSON.parse(e.data)
 		switch (msg.type) {
 			case 'initNewWidget':

--- a/src/js/materia/materia.creatorcore.test.js
+++ b/src/js/materia/materia.creatorcore.test.js
@@ -152,6 +152,12 @@ describe('creatorcore', () => {
 		expectOnlyCreatorMethodCalledToBe('onQuestionImportComplete')
 	})
 
+	it('reacts properly to post messages with non-string data', () => {
+		mockPostMessageFromWidget('', '', undefined)
+		console.log(window.addEventListener)
+		expect(window.addEventListener).toHaveLastReturnedWith(undefined)
+	})
+
 	it('reacts properly to unknown post messages', () => {
 		jest.spyOn(console, 'warn')
 		mockPostMessageFromWidget('undefinedMessageType', 'unknown-source', ['payload'])

--- a/src/js/materia/materia.enginecore.js
+++ b/src/js/materia/materia.enginecore.js
@@ -7,6 +7,7 @@ Namespace('Materia').Engine = (() => {
 	let _widgetClass = null
 
 	const _onPostMessage = e => {
+		if (typeof e.data !== 'string') return
 		const msg = JSON.parse(e.data)
 		switch (msg.type) {
 			case 'initWidget':

--- a/src/js/materia/materia.enginecore.test.js
+++ b/src/js/materia/materia.enginecore.test.js
@@ -101,6 +101,15 @@ describe('enginecore', () => {
 		expect(Engine.getMediaUrl('fR93X')).toBe('mediaUrl/fR93X')
 	})
 
+	it('reacts properly to post messages with non-string data', () => {
+		Engine.start({ start: jest.fn() })
+		let _onPostMessage = window.addEventListener.mock.calls[0][1]
+		_onPostMessage({
+			data: undefined
+		})
+		expect(parent.postMessage).toHaveLastReturnedWith(undefined)
+	})
+
 	it('end sends post message and defaults to show score screen', () => {
 		Engine.end()
 		let ex = JSON.stringify({


### PR DESCRIPTION
For issue #78 
- Added check of e.data in a POST request before it is passed to JSON.parse