### PR TITLE
Fixes drooping widget icons in the catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "materia-server-client-assets",
-  "version": "2.1.0",
+  "version": "2.1.1-alpha1",
   "license": "AGPL-3.0",
   "description": "Materia Server Client Assets contains all the javascript and css for Materia Server and the Materia Widget Development Kit.",
   "author": "University of Central Florida, Center for Distributed Learning",

--- a/src/css/widget-catalog.scss
+++ b/src/css/widget-catalog.scss
@@ -315,6 +315,7 @@
 
 				.img-holder {
 					position: absolute;
+					top: 0px;
 
 					img {
 						width: 115px;


### PR DESCRIPTION
I've only been able to reproduce it in Chrome:

![Screen Shot 2019-09-19 at 1 32 04 PM](https://user-images.githubusercontent.com/1268547/65266904-f8500000-dae1-11e9-89e9-603de1031e4c.png)
