### PR TITLE
#1259 lti picker refresh fix

### DIFF
--- a/src/js/controllers/ctrl-lti.js
+++ b/src/js/controllers/ctrl-lti.js
@@ -16,7 +16,7 @@ app.controller('ltiCtrl', function(Please, $interval, $timeout, $scope, $sce, wi
 
 		$timeout(
 			() =>
-				widgetSrv.getWidgets().then(widgets => {
+				widgetSrv.getWidgets(true).then(widgets => {
 					if (widgets != null ? widgets.halt : undefined) {
 						return
 					}

--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -185,15 +185,19 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 	const _getMultipleFromServer = () => {
 		const deferred = $q.defer()
 		Materia.Coms.Json.send('widget_instances_get', null).then(widgets => {
-			if (widgets && widgets.length > 0) {
+			if (widgets && widgets.length > 0 && widgets.length >= _widgets.length) {
+				let index = 0
+
 				widgets.forEach(w => {
-					if (_widgetIds[w.id] !== undefined) {
-						return
-					}
-					_widgetIds[w.id] = w
 					_initSearchCache(w)
-					_widgets.push(w)
+					_widgetIds[w.id] = w
+					_widgets.splice(index, 1, w)
+					index++
 				})
+			}
+
+			if (widgets.length < _widgets.length) {
+				_widgets = widgets
 			}
 
 			deferred.resolve(_widgets)

--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -7,10 +7,10 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 
 	const sortWidgets = () => _widgets.sort((a, b) => b.created_at - a.created_at)
 
-	const getWidgets = () => {
+	const getWidgets = (force = false) => {
 		const deferred = $q.defer()
 
-		if (_widgets.length === 0 || !gotAll) {
+		if (_widgets.length === 0 || !gotAll || force) {
 			gotAll = true
 			_getMultipleFromServer().then(widgets => {
 				_widgets = widgets.slice(0) // save a copy
@@ -187,6 +187,9 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		Materia.Coms.Json.send('widget_instances_get', null).then(widgets => {
 			if (widgets && widgets.length > 0) {
 				widgets.forEach(w => {
+					if (_widgetIds[w.id] !== undefined) {
+						return
+					}
 					_widgetIds[w.id] = w
 					_initSearchCache(w)
 					_widgets.push(w)


### PR DESCRIPTION
For [#1259](https://github.com/ucfopen/Materia/issues/1259) in the Materia repository.

- Add for update flag for when refresh is clicked in the lti list. Defaults to false so old functions should work the same
- Change get multiplefromserver to consistently update widgets in the list