### PR TITLE
issue/92 - get rid of blank option in collaborator selection

### DIFF
--- a/src/js/controllers/ctrl-collaboration.js
+++ b/src/js/controllers/ctrl-collaboration.js
@@ -255,7 +255,7 @@ app.controller('CollaborationController', function(
 	const _cancelDemote = user => {
 		user.warning = false
 		user.remove = false
-		return (user.access = ACCESS.FULL)
+		return (user.access = String(ACCESS.FULL))
 	}
 
 	$scope.inputs = { userSearchInput: '' }


### PR DESCRIPTION
Return the access level as a string in the `_cancelDemote` function so the comparison in `ng-selected` of the collaborator selection is true.

#92 