### PR TITLE
#78 Add data type check for scorecore

### DIFF
--- a/src/js/materia/materia.scorecore.js
+++ b/src/js/materia/materia.scorecore.js
@@ -4,6 +4,7 @@ Namespace('Materia').ScoreCore = (() => {
 	let _widgetClass = null
 
 	const _onPostMessage = e => {
+		if (typeof e.data !== 'string') return
 		const msg = JSON.parse(e.data)
 		switch (msg.type) {
 			case 'initWidget':


### PR DESCRIPTION
I fixed this in the engine and creator core but neglected to add it for score core. Just a small check to see if the data passed to JSON.parse is a string first.

See #78 for the original issue and #79 for the PR fixing it.