### PR TITLE
Widget Copy modal & Settings updates to better clarify permissions

### DIFF
--- a/src/css/my-widgets.scss
+++ b/src/css/my-widgets.scss
@@ -389,28 +389,55 @@
 		opacity: 0.5;
 	}
 
-	.page .controls div.delete_dialogue {
-		background: url(../../../img/delete-dialogue-bg.png) no-repeat center;
-		padding: 20px 0;
-		margin-bottom: 5px;
+	.page .controls .delete_dialogue {
 		text-align: center;
-	}
+		width: 345px;
+		margin: 0;
+		position: absolute;
+		padding: 21px 10px 17px;
+		box-sizing: border-box;
+		background: white;
+		border-radius: 10px;
+		box-shadow: 3px 1px 6px rgba(0, 0, 0, 0.3);
 
-	.page .controls div.delete_dialogue .action_button {
-		margin-top: 5px;
-	}
+		// css triangle arrow to point at delete link
+		&:before {
+			content: ' ';
+			height: 0;
+			position: absolute;
+			width: 0;
+			top: -35px;
+			right: 20px;
+			border: 20px solid transparent;
+			border-bottom-color: white;
+		}
 
-	.page .controls div.delete_dialogue .red {
-		background: #ca0000;
-		background-image: linear-gradient(#e10000, #ca0000);
-		border-color: #747474;
-		color: #ffffff;
-	}
+		.bottom_buttons {
+			margin-top: 18px;
+		}
 
-	.page .controls div.delete_dialogue .red:hover {
-		background: #ca0000;
-		background-image: linear-gradient(#ca0000, #e10000);
-		text-decoration: none;
+		.action_button {
+			margin-top: 5px;
+		}
+
+		.red {
+			background: #ca0000;
+			background-image: linear-gradient(#e10000, #ca0000);
+			border-color: #747474;
+			color: #ffffff;
+		}
+
+		.red:hover {
+			background: #ca0000;
+			background-image: linear-gradient(#ca0000, #e10000);
+			text-decoration: none;
+		}
+
+		.gray:hover {
+			background: #a2c129;
+			background-image: linear-gradient(#b8b8b8, #e4e4e4);
+			text-decoration: none;
+		}
 	}
 
 	.page .controls a.disabled,
@@ -423,12 +450,6 @@
 		color: #545454;
 		cursor: default;
 		opacity: 0.5;
-	}
-
-	.page .controls div.delete_dialogue .gray:hover {
-		background: #a2c129;
-		background-image: linear-gradient(#b8b8b8, #e4e4e4);
-		text-decoration: none;
 	}
 
 	.page .controls div.additional_options {

--- a/src/css/partials/_widget_availability_modal.scss
+++ b/src/css/partials/_widget_availability_modal.scss
@@ -93,7 +93,10 @@
 
 	.disabled {
 		pointer-events: none;
-		opacity: 0.4;
+		label,
+		input {
+			opacity: 0.4;
+		}
 	}
 
 	h3 {

--- a/src/css/partials/_widget_availability_modal.scss
+++ b/src/css/partials/_widget_availability_modal.scss
@@ -35,7 +35,7 @@
 		}
 
 		&.inline {
-			margin: 50px auto 20px auto;
+			margin: 20px auto 20px auto;
 			padding: 0;
 			width: 255px;
 		}
@@ -148,17 +148,20 @@
 		}
 	}
 
-	.data_explanation {
-		margin-left: 125px;
-		width: 450px;
-		font-size: 14px;
+	.input_desc {
+		padding: 10px;
+		margin-bottom: 0;
+		background: #f2f2f2;
+		border-radius: 5px;
+		margin: 0.5em 1em 1em;
+
+		.desc_notice {
+			margin-top: 1em;
+		}
 	}
 
-	.access_explanation {
-		margin-left: 15px;
-		width: 450px;
-		font-size: 14px;
-		margin: 5px 20px;
+	.data_explanation {
+		margin-left: 125px;
 	}
 
 	.ui-slider-handle.ui-state-default.ui-corner-all {

--- a/src/css/partials/_widget_availability_modal.scss
+++ b/src/css/partials/_widget_availability_modal.scss
@@ -16,6 +16,16 @@
 		text-align: left;
 	}
 
+	.student-role-notice {
+		margin: 0 auto 15px auto;
+		padding: 10px;
+		font-size: 0.9em;
+		width: 90%;
+
+		background: rgb(238, 238, 238);
+		border-radius: 5px;
+	}
+
 	ul {
 		&.inline li {
 			list-style: none;

--- a/src/css/partials/_widget_copy_modal.scss
+++ b/src/css/partials/_widget_copy_modal.scss
@@ -4,7 +4,7 @@
 
 .ng-modal.copy .adding_shadow {
 	width: 640px;
-	height: 480px;
+	height: 540px;
 	background-color: #000000;
 	border-radius: 3px;
 	position: absolute;
@@ -21,6 +21,29 @@
 	top: 40px;
 	width: 600px;
 	padding-top: 15px;
+
+	div {
+		margin: 20px 0 0 0;
+		padding: 20px 0 20px 15px;
+
+		text-align: left;
+
+		border-top: solid 1px rgb(238, 238, 238);
+		border-bottom: solid 1px rgb(238, 238, 238);
+
+		font-size: 14px;
+
+		p {
+			padding: 10px;
+			margin-bottom: 0;
+			background: rgb(238, 238, 238);
+			border-radius: 5px;
+		}
+
+		input {
+			margin-right: 12px;
+		}
+	}
 }
 
 .ng-modal.copy .ng-modal-title {

--- a/src/css/partials/_widget_copy_modal.scss
+++ b/src/css/partials/_widget_copy_modal.scss
@@ -1,126 +1,76 @@
 .ng-modal.copy {
-	text-align: center;
-}
+	// START MODAL PARTS
 
-.ng-modal.copy .adding_shadow {
-	width: 640px;
-	height: 540px;
-	background-color: #000000;
-	border-radius: 3px;
-	position: absolute;
-	top: -65px;
-	left: -20px;
-	z-index: 1;
-	opacity: 0;
-	filter: alpha(opacity=0);
-}
+	.ng-modal-dialog {
+		padding: 20px 20px 5px 20px;
+		min-width: 500px;
+	}
 
-.ng-modal.copy .container {
-	position: absolute;
-	left: 20px;
-	top: 40px;
-	width: 600px;
-	padding-top: 15px;
-
-	div {
-		margin: 20px 0 0 0;
-		padding: 20px 0 20px 15px;
-
+	.ng-modal-title {
+		margin: 0;
+		padding: 0;
+		font-size: 1.3em;
+		color: #555;
+		border-bottom: #999 dotted 1px;
+		padding-bottom: 20px;
+		margin-bottom: 20px;
+		position: relative;
 		text-align: left;
+	}
 
-		border-top: solid 1px rgb(238, 238, 238);
-		border-bottom: solid 1px rgb(238, 238, 238);
+	a.close {
+		display: block;
+		position: absolute;
+		right: 5px;
+		top: 4px;
+		margin: 4px;
+		background: url('../../../img/close.png') no-repeat;
+		text-indent: -10000px;
+		width: 19px;
+		height: 19px;
+	}
 
-		font-size: 14px;
+	.container {
+		width: 100%;
+	}
 
-		p {
-			padding: 10px;
-			margin-bottom: 0;
-			background: rgb(238, 238, 238);
-			border-radius: 5px;
+	// END MODAL PARTS
+
+	.input_desc {
+		padding: 10px;
+		margin-bottom: 0;
+		background: #f2f2f2;
+		border-radius: 5px;
+		margin: 0.5em 1em 1em;
+	}
+
+	.title_container {
+		label {
+			margin: 0 25px 0 0;
 		}
 
-		input {
-			margin-right: 12px;
+		#copy_input_title {
+			width: 450px;
+			height: 30px;
+			padding-left: 10px;
+			position: relative;
+			z-index: 2;
 		}
 	}
-}
 
-.ng-modal.copy .ng-modal-title {
-	top: 3px;
-	left: 12px;
-}
+	.options_container {
+		margin: 20px 0 0 0;
+		padding: 20px 0 0 0;
+		text-align: left;
 
-.ng-modal.copy a.close {
-	display: block;
-	position: absolute;
-	right: 5px;
-	top: 4px;
-	margin: 4px;
-	background: url('../../../img/close.png') no-repeat;
-	text-indent: -10000px;
-	width: 19px;
-	height: 19px;
-}
+		input {
+			margin-right: 5px;
+		}
+	}
 
-.ng-modal.copy .input_label {
-	font-size: 16px;
-	margin: 0 25px 0 0;
-}
-
-.ng-modal.copy input.newtitle {
-	width: 450px;
-	height: 30px;
-	padding-left: 10px;
-	position: relative;
-	z-index: 2;
-}
-
-.ng-modal.copy .copy_button {
-	margin-top: 20px;
-}
-
-.ng-modal.copy .copy_error {
-	display: none;
-	color: #ee0000;
-	margin-top: 5px;
-}
-
-.share .perm-text {
-	width: 100%;
-	display: inline-block;
-}
-
-.share .exp-date {
-	padding: 0;
-	text-decoration: underline;
-	color: #545454;
-	font-size: 8pt;
-	cursor: pointer;
-	background: transparent;
-	border: none;
-	width: 85px;
-}
-.share .exp-date:hover {
-	color: #969696;
-}
-.share .exp-date:disabled {
-	cursor: default;
-	color: #c5c5c5;
-	text-decoration: none;
-}
-
-.share .exp-date:focus {
-	outline: none;
-	background: #fff;
-	border: solid 1px #f7b64a;
-}
-
-.share .expires {
-	font-size: 8pt;
-}
-
-.share .remove-expiration {
-	font-size: 8pt;
-	cursor: pointer;
+	.bottom_buttons {
+		margin-top: 20px;
+		text-align: center;
+		width: 100%;
+	}
 }

--- a/src/css/partials/_widget_share_modal.scss
+++ b/src/css/partials/_widget_share_modal.scss
@@ -13,6 +13,12 @@
 	left: 250px;
 }
 
+.ng-modal.share .search_container {
+	text-align: left;
+	position: relative;
+	margin-bottom: 20px;
+}
+
 .ng-modal.share .action_button.save_button {
 	position: absolute;
 	bottom: -35px;
@@ -67,15 +73,21 @@
 
 .ng-modal.share .container {
 	left: 0;
-	top: 50px;
 	width: 580px;
 	height: 390px;
-	padding-top: 15px;
+	padding-top: 0;
 }
 
 .ng-modal.share .ng-modal-title {
-	top: 15px;
-	left: 27px;
+	margin: 0;
+	padding: 0;
+	font-size: 1.3em;
+	color: #555;
+	border-bottom: #999 dotted 1px;
+	padding-bottom: 20px;
+	margin-bottom: 20px;
+	position: relative;
+	text-align: left;
 }
 
 .ng-modal.share a.close {
@@ -115,9 +127,7 @@
 
 .ng-modal.share .input_label {
 	font-size: 19px;
-	margin: 0 25px 0 0;
-
-	position: absolute;
+	margin: 5px 25px 0 0;
 }
 
 .ng-modal.share #adding .input_label {
@@ -129,13 +139,9 @@
 .ng-modal.share #access .placeholder {
 	width: 445px;
 	height: 30px;
-	padding-left: 10px;
 	z-index: 2;
 	border: solid 1px #c9c9c9;
 	font-size: 16px;
-
-	position: absolute;
-	right: 0;
 }
 
 .ng-modal.share #adding #input_holder {
@@ -265,7 +271,6 @@
 	height: 250px;
 	-moz-border-radius: 5px;
 	border-radius: 5px;
-	margin-top: 50px;
 	padding: 0 30px;
 	text-align: right;
 	overflow: auto;
@@ -577,4 +582,47 @@
 	color: #555;
 	text-decoration: underline;
 	font-size: 12pt;
+}
+
+.share {
+	.perm-text {
+		width: 100%;
+		display: inline-block;
+	}
+
+	.exp-date {
+		padding: 0;
+		text-decoration: underline;
+		color: #545454;
+		font-size: 8pt;
+		cursor: pointer;
+		background: transparent;
+		border: none;
+		width: 85px;
+
+		&:hover {
+			color: #969696;
+		}
+
+		&:disabled {
+			cursor: default;
+			color: #c5c5c5;
+			text-decoration: none;
+		}
+
+		&:focus {
+			outline: none;
+			background: #fff;
+			border: solid 1px #f7b64a;
+		}
+	}
+
+	.expires {
+		font-size: 8pt;
+	}
+
+	.remove-expiration {
+		font-size: 8pt;
+		cursor: pointer;
+	}
 }

--- a/src/css/partials/_widget_share_modal.scss
+++ b/src/css/partials/_widget_share_modal.scss
@@ -1,39 +1,556 @@
-.ng-modal.share .cancel_button {
-	position: absolute;
-	bottom: -35px;
-	left: 200px;
-
-	color: #555;
-	text-decoration: underline;
-	margin: 10px 15px;
-	cursor: pointer;
+.ng-modal.share .avatar,
+.user_perm_name,
+.user-perm .options,
+.user_perm_select,
+.user_match_avatar,
+.user_match_name {
+	display: inline-block;
+	vertical-align: middle;
 }
 
-.ng-modal.share .cancel_button.close_only {
-	left: 250px;
-}
+.ng-modal.share {
+	text-align: center;
 
-.ng-modal.share .search_container {
-	text-align: left;
-	position: relative;
-	margin-bottom: 20px;
-}
+	.cancel_button {
+		position: absolute;
+		bottom: -35px;
+		left: 200px;
 
-.ng-modal.share .action_button.save_button {
-	position: absolute;
-	bottom: -35px;
-	left: 285px;
-}
+		color: #555;
+		text-decoration: underline;
+		margin: 10px 15px;
+		cursor: pointer;
+	}
 
-.ng-modal.share .toggle_transfer {
-	font-size: 12px;
-	position: absolute;
-	bottom: 20px;
-	left: 20px;
-	padding: 5px 10px;
-}
-.ng-modal.share .cancel_button .share_button {
-	margin-top: 10px;
+	.cancel_button.close_only {
+		left: 250px;
+	}
+
+	.search_container {
+		text-align: left;
+		position: relative;
+		margin-bottom: 20px;
+	}
+
+	.action_button.save_button {
+		position: absolute;
+		bottom: -35px;
+		left: 285px;
+	}
+
+	.toggle_transfer {
+		font-size: 12px;
+		position: absolute;
+		bottom: 20px;
+		left: 20px;
+		padding: 5px 10px;
+	}
+	.cancel_button .share_button {
+		margin-top: 10px;
+	}
+
+	#adding {
+		background-color: #f0f0f0;
+		border: none;
+		background: transparent;
+		position: absolute;
+		top: 0;
+	}
+
+	.container {
+		left: 0;
+		width: 580px;
+		height: 390px;
+		padding-top: 0;
+	}
+
+	.ng-modal-title {
+		margin: 0;
+		padding: 0;
+		font-size: 1.3em;
+		color: #555;
+		border-bottom: #999 dotted 1px;
+		padding-bottom: 20px;
+		margin-bottom: 20px;
+		position: relative;
+		text-align: left;
+	}
+
+	a.close {
+		display: block;
+		position: absolute;
+		right: 5px;
+		top: 4px;
+		margin: 4px;
+		background: url('../../../img/close.png') no-repeat;
+		text-indent: -10000px;
+		width: 19px;
+		height: 19px;
+	}
+	a.remove {
+		display: inline-block;
+		color: #bfbfbf;
+		text-decoration: none;
+		font-size: 15px;
+		position: absolute;
+		left: 5px;
+		top: 30px;
+	}
+	.name {
+		float: left;
+		font-weight: bold;
+		font-size: 15px;
+		margin-top: 8px;
+		text-align: left;
+		width: 160px;
+	}
+
+	.name span {
+		display: block;
+		font-weight: normal;
+		text-align: left;
+	}
+
+	.input_label {
+		font-size: 19px;
+		margin: 5px 25px 0 0;
+	}
+
+	#adding .input_label {
+		left: 20px;
+		top: 20px;
+	}
+
+	#access input.user_add,
+	#access .placeholder {
+		width: 445px;
+		height: 30px;
+		z-index: 2;
+		border: solid 1px #c9c9c9;
+		font-size: 16px;
+	}
+
+	#adding #input_holder {
+		width: 445px;
+		height: 30px;
+		padding-left: 10px;
+		z-index: 2;
+		border: solid 1px #c9c9c9;
+		font-size: 16px;
+		background: #fff;
+		position: absolute;
+		right: 0;
+		text-align: left;
+		top: 20px;
+		right: 20px;
+	}
+
+	#adding #input_area {
+		display: inline-block;
+		outline: none;
+		min-width: 15px;
+		min-height: 30px;
+		font-family: 'Lucida Grande', sans-serif;
+		font-size: 16px;
+		padding-top: 5px;
+	}
+	#adding #input_area input.user_add {
+		width: 460px;
+		height: 30px;
+		border: none;
+		margin: 0;
+		padding: 0;
+		display: inline-block;
+	}
+
+	#adding #input_area input.user_add::input-placeholder {
+		color: #343434;
+	}
+
+	#adding #expArea {
+		display: block;
+	}
+	#adding #expArea #expSet {
+		display: none;
+		padding: 0;
+		margin: 0;
+	}
+	.expElement {
+		padding: 0;
+		margin: 0 5px;
+	}
+
+	.changeRoleExpiration {
+		display: none;
+	}
+
+	#adding #expArea .exp_disclaimer {
+		padding: 0;
+		margin: 10px 0;
+	}
+	#adding #expArea #roleExpiration {
+		width: 100px;
+	}
+
+	.share_user_to_add {
+		display: inline-block;
+		font-size: 14px;
+		border-radius: 3px;
+		background-color: #fbfbfb;
+		border: 1px solid #aeaeae;
+		margin: 3px;
+		padding: 3px;
+		height: 30px;
+	}
+
+	.search_list {
+		width: 456px;
+		min-height: 130px;
+		height: 340px;
+		position: absolute;
+		background-color: #ffffff;
+		border: #bfbfbf 1px solid;
+		padding-bottom: 5px;
+		overflow: auto;
+		z-index: 3;
+		text-align: left;
+		top: 50px;
+		left: 120px;
+	}
+	.no_match_message,
+	.no_match_reason {
+		width: 60%;
+		text-align: center;
+		margin: 10px auto;
+	}
+
+	.no_match_reason {
+		color: #a0a0a0;
+		font-size: 14px;
+	}
+
+	.search_match {
+		width: 200px;
+		height: 56px;
+		margin: 5px 5px 0 5px;
+		padding: 0 5px 5px 0;
+		border-radius: 3px;
+		display: inline-block;
+		background-color: #ffffff;
+	}
+	.search_match:hover {
+		background-color: #c5e7fa;
+		cursor: pointer;
+	}
+	.search_match.focused {
+		background-color: #7fc9f3;
+	}
+	.access_list {
+		background-color: #f2f2f2;
+		width: 520px;
+		height: 250px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+		padding: 0 30px;
+		text-align: right;
+		overflow: auto;
+	}
+
+	.access_list.no-add-access {
+		background-color: #f2f2f2;
+		height: 320px;
+		margin-top: 0px;
+	}
+
+	.access_heading {
+		margin: 5px 125px 0 0;
+		padding: 0;
+	}
+
+	.user_match_name {
+		font-size: 14px;
+		text-align: left;
+		width: 140px;
+		height: 40px;
+		font-family: 'Lucida Grande', sans-serif;
+	}
+	.user_match_student {
+		position: relative;
+	}
+	.user_match_student:after {
+		content: 'Student';
+		position: absolute;
+		top: -10px;
+		left: 0;
+		font-size: 10px;
+	}
+
+	.disclaimer {
+		color: #575757;
+		font-size: 14px;
+		margin-top: 10px;
+	}
+
+	.user_perm {
+		border-bottom: #e1e1e1 1px solid;
+		margin: 5px 0;
+		margin: 0;
+	}
+
+	.user_perm:last-child {
+		border: none;
+	}
+
+	.user_perm {
+		width: 420px;
+		min-height: 64px;
+		vertical-align: middle;
+		position: relative;
+		margin-left: auto;
+		margin-right: auto;
+		display: block;
+		padding: 15px 0 0 0;
+	}
+
+	.user_perm .options {
+		position: absolute;
+		right: 0;
+		width: 145px;
+		float: left;
+		text-align: left;
+		margin-top: 6px;
+	}
+
+	.user_perm .options select {
+		display: block;
+	}
+
+	.avatar {
+		margin-left: 40px;
+	}
+
+	.avatar,
+	.user_match_avatar {
+		width: 50px;
+		height: 50px;
+		-moz-border-radius: 3px;
+		border-radius: 3px;
+		display: inline-block;
+		float: left;
+		margin-right: 10px;
+		margin: 5px;
+	}
+
+	.user_perm_name {
+		width: 187px;
+		font-size: 15px;
+		text-align: left;
+		padding: 0 0 0 18px;
+		margin: 0;
+		font-weight: bold;
+	}
+
+	.user_perm_name span {
+		display: block;
+		font-weight: normal;
+	}
+
+	.user_perm_select {
+		width: 150px;
+		height: 20px;
+		margin-right: 33px;
+		text-align: left;
+	}
+
+	#adding .options {
+		width: 450px;
+		margin: 10px 25px 0 0;
+		float: right;
+	}
+	#adding .user_perm_select {
+		margin-left: 8px;
+	}
+
+	hr {
+		width: 100%;
+		border: 1px dotted;
+		margin: 10px 0;
+	}
+
+	.user_perm_check {
+		float: left;
+		margin-bottom: 10px;
+	}
+
+	.user_perm_message {
+		display: block;
+		text-align: left;
+		width: 426px;
+	}
+	#adding textarea {
+		resize: none;
+	}
+
+	.options {
+		text-align: right;
+	}
+
+	.owner {
+		display: none;
+		width: 145px;
+		text-align: left;
+	}
+
+	.owner a {
+		display: block;
+		font-size: 13px;
+	}
+
+	.transfer {
+		display: none;
+	}
+
+	a.cancel-transfer {
+		display: inline !important;
+	}
+
+	.transfer .do-transfer,
+	.transfer span {
+		display: none;
+	}
+
+	.transfer span {
+		font-size: 14px;
+	}
+
+	.owner .transfer-owner {
+		display: none;
+	}
+
+	.undo {
+		display: none;
+		width: 145px;
+		text-align: left;
+	}
+
+	.deleted .avatar {
+		opacity: 0.5;
+	}
+
+	.deleted .name {
+		color: #5f5f5f;
+	}
+
+	.user_perm .exp_change_view {
+		display: none;
+		text-align: right;
+		background: #f2f2f2;
+
+		position: absolute;
+		top: 0;
+		right: 0;
+		height: 64px;
+		font-size: 12px;
+		top: -15px;
+		width: 225px;
+		padding-left: 16px;
+
+		background: white;
+		border-radius: 1px;
+		box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
+	}
+
+	.user_perm .exp_change_view .access_expires {
+		text-align: left;
+		font-family: 'Lato';
+		font-size: 13px;
+		line-height: 0;
+		padding-top: 6px;
+	}
+
+	.user_perm label {
+		margin-right: 10px;
+	}
+
+	.exp_change_view .exp_button {
+		font-family: Lato, arial, serif;
+		position: absolute;
+		top: 10px;
+		right: 10px;
+	}
+
+	.exp_change_view .gray_min {
+		background: #aeaeae;
+		color: #545454;
+	}
+	.exp_change_view .gray_min:hover {
+		background: #919191;
+	}
+	.exp_change_view .green_min {
+		background: #b2cd43;
+		color: #4d5822;
+	}
+	.exp_change_view .green_min:hover {
+		background: #a2c129;
+	}
+
+	.exp_change_view input[type='text'] {
+		display: none;
+		position: absolute;
+		width: 75px;
+		left: 145px;
+	}
+
+	.demote_dialogue {
+		border-radius: 4px;
+		box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
+		padding: 1em;
+		width: 310px;
+		font-family: 'Lucida Grande', sans-serif;
+		font-size: 9pt;
+		color: black;
+		text-align: center;
+		background: #fcdbdb;
+		height: 40px;
+		z-index: 10000;
+		position: absolute;
+		margin-left: 90px;
+	}
+
+	.demote_dialogue .arrow {
+		background: url('../../../img/pink-arrow-left.png') no-repeat 0 center;
+		width: 13px;
+		height: 23px;
+		display: inline-block;
+		top: 0;
+		left: -13px;
+		position: absolute;
+		height: 100%;
+	}
+
+	.demote_dialogue .warning {
+		display: block;
+		margin: -4px 0 6px 0;
+		text-align: center;
+	}
+
+	.demote_dialogue .button {
+		text-align: center;
+		margin: 0 10px 0 10px;
+	}
+
+	.demote_dialogue .red {
+		color: white;
+		font-size: 11pt;
+		padding: 5px 12px;
+	}
+
+	.demote_dialogue .no_button {
+		font-family: Lato, arial, serif;
+		color: #555;
+		text-decoration: underline;
+		font-size: 12pt;
+	}
 }
 
 .ng-modal .green {
@@ -59,529 +576,10 @@
 	text-decoration: none;
 }
 
-.ng-modal.share {
-	text-align: center;
-}
-
-.ng-modal.share #adding {
-	background-color: #f0f0f0;
-	border: none;
-	background: transparent;
-	position: absolute;
-	top: 0;
-}
-
-.ng-modal.share .container {
-	left: 0;
-	width: 580px;
-	height: 390px;
-	padding-top: 0;
-}
-
-.ng-modal.share .ng-modal-title {
-	margin: 0;
-	padding: 0;
-	font-size: 1.3em;
-	color: #555;
-	border-bottom: #999 dotted 1px;
-	padding-bottom: 20px;
-	margin-bottom: 20px;
-	position: relative;
-	text-align: left;
-}
-
-.ng-modal.share a.close {
-	display: block;
-	position: absolute;
-	right: 5px;
-	top: 4px;
-	margin: 4px;
-	background: url('../../../img/close.png') no-repeat;
-	text-indent: -10000px;
-	width: 19px;
-	height: 19px;
-}
-.ng-modal.share a.remove {
-	display: inline-block;
-	color: #bfbfbf;
-	text-decoration: none;
-	font-size: 15px;
-	position: absolute;
-	left: 5px;
-	top: 30px;
-}
-.ng-modal.share .name {
-	float: left;
-	font-weight: bold;
-	font-size: 15px;
-	margin-top: 8px;
-	text-align: left;
-	width: 160px;
-}
-
-.ng-modal.share .name span {
-	display: block;
-	font-weight: normal;
-	text-align: left;
-}
-
-.ng-modal.share .input_label {
-	font-size: 19px;
-	margin: 5px 25px 0 0;
-}
-
-.ng-modal.share #adding .input_label {
-	left: 20px;
-	top: 20px;
-}
-
-.ng-modal.share #access input.user_add,
-.ng-modal.share #access .placeholder {
-	width: 445px;
-	height: 30px;
-	z-index: 2;
-	border: solid 1px #c9c9c9;
-	font-size: 16px;
-}
-
-.ng-modal.share #adding #input_holder {
-	width: 445px;
-	height: 30px;
-	padding-left: 10px;
-	z-index: 2;
-	border: solid 1px #c9c9c9;
-	font-size: 16px;
-	background: #fff;
-	position: absolute;
-	right: 0;
-	text-align: left;
-	top: 20px;
-	right: 20px;
-}
-
-.ng-modal.share #adding #input_area {
-	display: inline-block;
-	outline: none;
-	min-width: 15px;
-	min-height: 30px;
-	font-family: 'Lucida Grande', sans-serif;
-	font-size: 16px;
-	padding-top: 5px;
-}
-.ng-modal.share #adding #input_area input.user_add {
-	width: 460px;
-	height: 30px;
-	border: none;
-	margin: 0;
-	padding: 0;
-	display: inline-block;
-}
-
-.ng-modal.share #adding #input_area input.user_add::input-placeholder {
-	color: #343434;
-}
-
-.ng-modal.share #adding #expArea {
-	display: block;
-}
-.ng-modal.share #adding #expArea #expSet {
-	display: none;
-	padding: 0;
-	margin: 0;
-}
-.ng-modal.share .expElement {
-	padding: 0;
-	margin: 0 5px;
-}
-
-.ng-modal.share .changeRoleExpiration {
-	display: none;
-}
-
-.ng-modal.share #adding #expArea .exp_disclaimer {
-	padding: 0;
-	margin: 10px 0;
-}
-.ng-modal.share #adding #expArea #roleExpiration {
-	width: 100px;
-}
-
-.ng-modal.share .share_user_to_add {
-	display: inline-block;
-	font-size: 14px;
-	border-radius: 3px;
-	background-color: #fbfbfb;
-	border: 1px solid #aeaeae;
-	margin: 3px;
-	padding: 3px;
-	height: 30px;
-}
-
 .share_user_to_add_name {
 	vertical-align: middle;
 	padding: 0;
 	margin: 0;
-}
-
-.ng-modal.share .search_list {
-	width: 456px;
-	min-height: 130px;
-	height: 340px;
-	position: absolute;
-	background-color: #ffffff;
-	border: #bfbfbf 1px solid;
-	padding-bottom: 5px;
-	overflow: auto;
-	z-index: 3;
-	text-align: left;
-	top: 50px;
-	left: 120px;
-}
-.ng-modal.share .no_match_message,
-.ng-modal.share .no_match_reason {
-	width: 60%;
-	text-align: center;
-	margin: 10px auto;
-}
-
-.ng-modal.share .no_match_reason {
-	color: #a0a0a0;
-	font-size: 14px;
-}
-
-.ng-modal.share .search_match {
-	width: 200px;
-	height: 56px;
-	margin: 5px 5px 0 5px;
-	padding: 0 5px 5px 0;
-	border-radius: 3px;
-	display: inline-block;
-	background-color: #ffffff;
-}
-.ng-modal.share .search_match:hover {
-	background-color: #c5e7fa;
-	cursor: pointer;
-}
-.ng-modal.share .search_match.focused {
-	background-color: #7fc9f3;
-}
-.ng-modal.share .access_list {
-	background-color: #f2f2f2;
-	width: 520px;
-	height: 250px;
-	-moz-border-radius: 5px;
-	border-radius: 5px;
-	padding: 0 30px;
-	text-align: right;
-	overflow: auto;
-}
-
-.ng-modal.share .access_list.no-add-access {
-	background-color: #f2f2f2;
-	height: 320px;
-	margin-top: 0px;
-}
-
-.ng-modal.share .access_heading {
-	margin: 5px 125px 0 0;
-	padding: 0;
-}
-.ng-modal.share .user_match_avatar {
-	float: left;
-	margin: 5px;
-}
-.ng-modal.share .user_match_name {
-	font-size: 14px;
-	text-align: left;
-	width: 140px;
-	height: 40px;
-	font-family: 'Lucida Grande', sans-serif;
-}
-.ng-modal.share .user_match_student {
-	position: relative;
-}
-.ng-modal.share .user_match_student:after {
-	content: 'Student';
-	position: absolute;
-	top: -10px;
-	left: 0;
-	font-size: 10px;
-}
-
-.ng-modal.share .disclaimer {
-	color: #575757;
-	font-size: 14px;
-	margin-top: 10px;
-}
-
-.ng-modal.share .user_perm {
-	border-bottom: #e1e1e1 1px solid;
-	margin: 5px 0;
-	margin: 0;
-}
-
-.ng-modal.share .user_perm:last-child {
-	border: none;
-}
-
-.ng-modal.share .user_perm {
-	width: 420px;
-	min-height: 64px;
-	vertical-align: middle;
-	position: relative;
-	margin-left: auto;
-	margin-right: auto;
-	display: block;
-	padding: 15px 0 0 0;
-}
-
-.ng-modal.share .user_perm .options {
-	position: absolute;
-	right: 0;
-	width: 145px;
-	float: left;
-	text-align: left;
-	margin-top: 6px;
-}
-
-.ng-modal.share .user_perm .options select {
-	display: block;
-}
-
-.ng-modal.share .avatar,
-.user_perm_name,
-.user-perm .options,
-.user_perm_select,
-.user_match_avatar,
-.user_match_name {
-	display: inline-block;
-	vertical-align: middle;
-}
-
-.ng-modal.share .avatar {
-	margin-left: 40px;
-}
-
-.ng-modal.share .avatar,
-.user_match_avatar {
-	width: 50px;
-	height: 50px;
-	-moz-border-radius: 3px;
-	border-radius: 3px;
-	display: inline-block;
-	float: left;
-	margin-right: 10px;
-}
-
-.ng-modal.share .user_perm_name {
-	width: 187px;
-	font-size: 15px;
-	text-align: left;
-	padding: 0 0 0 18px;
-	margin: 0;
-	font-weight: bold;
-}
-
-.ng-modal.share .user_perm_name span {
-	display: block;
-	font-weight: normal;
-}
-
-.ng-modal.share .user_perm_select {
-	width: 150px;
-	height: 20px;
-	margin-right: 33px;
-	text-align: left;
-}
-
-.ng-modal.share #adding .options {
-	width: 450px;
-	margin: 10px 25px 0 0;
-	float: right;
-}
-.ng-modal.share #adding .user_perm_select {
-	margin-left: 8px;
-}
-
-.ng-modal.share hr {
-	width: 100%;
-	border: 1px dotted;
-	margin: 10px 0;
-}
-
-.ng-modal.share .user_perm_check {
-	float: left;
-	margin-bottom: 10px;
-}
-
-.ng-modal.share .user_perm_message {
-	display: block;
-	text-align: left;
-	width: 426px;
-}
-.ng-modal.share #adding textarea {
-	resize: none;
-}
-
-.ng-modal.share .options {
-	text-align: right;
-}
-
-.ng-modal.share .owner {
-	display: none;
-	width: 145px;
-	text-align: left;
-}
-
-.ng-modal.share .owner a {
-	display: block;
-	font-size: 13px;
-}
-
-.ng-modal.share .transfer {
-	display: none;
-}
-
-.ng-modal.share a.cancel-transfer {
-	display: inline !important;
-}
-
-.ng-modal.share .transfer .do-transfer,
-.ng-modal.share .transfer span {
-	display: none;
-}
-
-.ng-modal.share .transfer span {
-	font-size: 14px;
-}
-
-.ng-modal.share .owner .transfer-owner {
-	display: none;
-}
-
-.ng-modal.share .undo {
-	display: none;
-	width: 145px;
-	text-align: left;
-}
-
-.ng-modal.share .deleted .avatar {
-	opacity: 0.5;
-}
-
-.ng-modal.share .deleted .name {
-	color: #5f5f5f;
-}
-
-.ng-modal.share .user_perm .exp_change_view {
-	display: none;
-	text-align: right;
-	background: #f2f2f2;
-
-	position: absolute;
-	top: 0;
-	right: 0;
-	height: 64px;
-	font-size: 12px;
-	top: -15px;
-	width: 225px;
-	padding-left: 16px;
-
-	background: white;
-	border-radius: 1px;
-	box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
-}
-
-.ng-modal.share .user_perm .exp_change_view .access_expires {
-	text-align: left;
-	font-family: 'Lato';
-	font-size: 13px;
-	line-height: 0;
-	padding-top: 6px;
-}
-
-.ng-modal.share .user_perm label {
-	margin-right: 10px;
-}
-
-.ng-modal.share .exp_change_view .exp_button {
-	font-family: Lato, arial, serif;
-	position: absolute;
-	top: 10px;
-	right: 10px;
-}
-
-.ng-modal.share .exp_change_view .gray_min {
-	background: #aeaeae;
-	color: #545454;
-}
-.ng-modal.share .exp_change_view .gray_min:hover {
-	background: #919191;
-}
-.ng-modal.share .exp_change_view .green_min {
-	background: #b2cd43;
-	color: #4d5822;
-}
-.ng-modal.share .exp_change_view .green_min:hover {
-	background: #a2c129;
-}
-
-.ng-modal.share .exp_change_view input[type='text'] {
-	display: none;
-	position: absolute;
-	width: 75px;
-	left: 145px;
-}
-
-.ng-modal.share .demote_dialogue {
-	border-radius: 4px;
-	box-shadow: 0 2px 2px rgba(0, 0, 0, 0.3);
-	padding: 1em;
-	width: 310px;
-	font-family: 'Lucida Grande', sans-serif;
-	font-size: 9pt;
-	color: black;
-	text-align: center;
-	background: #fcdbdb;
-	height: 40px;
-	z-index: 10000;
-	position: absolute;
-	margin-left: 90px;
-}
-
-.ng-modal.share .demote_dialogue .arrow {
-	background: url('../../../img/pink-arrow-left.png') no-repeat 0 center;
-	width: 13px;
-	height: 23px;
-	display: inline-block;
-	top: 0;
-	left: -13px;
-	position: absolute;
-	height: 100%;
-}
-
-.ng-modal.share .demote_dialogue .warning {
-	display: block;
-	margin: -4px 0 6px 0;
-	text-align: center;
-}
-
-.ng-modal.share .demote_dialogue .button {
-	text-align: center;
-	margin: 0 10px 0 10px;
-}
-
-.ng-modal.share .demote_dialogue .red {
-	color: white;
-	font-size: 11pt;
-	padding: 5px 12px;
-}
-
-.ng-modal.share .demote_dialogue .no_button {
-	font-family: Lato, arial, serif;
-	color: #555;
-	text-decoration: underline;
-	font-size: 12pt;
 }
 
 .share {

--- a/src/js/controllers/ctrl-selectedwidget.js
+++ b/src/js/controllers/ctrl-selectedwidget.js
@@ -30,7 +30,11 @@ app.controller('SelectedWidgetController', function(
 
 	const _copyWidget = () => {
 		widgetSrv
-			.copyWidget($scope.selected.widget.id, $scope.selected.copy_title)
+			.copyWidget(
+				$scope.selected.widget.id,
+				$scope.selected.copy_title,
+				$scope.selected.copy_retain_access
+			)
 			.then(inst_id => {
 				$scope.show.copyModal = false
 				return widgetSrv.getWidget(inst_id)

--- a/src/js/controllers/ctrl-widget-settings.js
+++ b/src/js/controllers/ctrl-widget-settings.js
@@ -50,22 +50,35 @@ app.controller('WidgetSettingsController', function(
 	}
 
 	const _toggleNormalAccess = () => {
-		if (($scope.guestAccess = true)) {
-			$scope.guestAccess = false
-		}
-		if (($scope.embeddedOnly = true)) {
+		// disallow student made widgets from being toggled out of guest mode
+		if ($scope.studentMade) return
+
+		$scope.guestAccess = !$scope.guestAccess
+
+		if ($scope.embeddedOnly == true) {
 			$scope.embeddedOnly = false
+		}
+
+		// warn user that students will be removed if guest mode is disabled
+		if ($scope.selected.widget.student_access == true && $scope.guestAccess == false) {
+			$scope.alert.msg =
+				'Warning: Disabling Guest Mode will automatically revoke access to this widget for any students it has been shared with!'
+			$scope.alert.title = 'Students with access will be removed'
+			$scope.alert.fatal = false
 		}
 	}
 
 	const _toggleGuestAccess = () => {
+		// disallow student made widgets from being toggled out of guest mode
 		if ($scope.studentMade) return
 
 		$scope.guestAccess = !$scope.guestAccess
 		if ($scope.guestAccess) {
 			$scope.embeddedOnly = false
 		}
-		if ($scope.selected.widget.student_access === true && $scope.guestAccess === false) {
+
+		// warn user that students will be removed if guest mode is disabled
+		if ($scope.selected.widget.student_access == true && $scope.guestAccess == false) {
 			$scope.alert.msg =
 				'Warning: Disabling Guest Mode will automatically revoke access to this widget for any students it has been shared with!'
 			$scope.alert.title = 'Students with access will be removed'

--- a/src/js/controllers/ctrl-widget-settings.js
+++ b/src/js/controllers/ctrl-widget-settings.js
@@ -66,6 +66,8 @@ app.controller('WidgetSettingsController', function(
 			$scope.alert.title = 'Students with access will be removed'
 			$scope.alert.fatal = false
 		}
+
+		_updateSliderAfterChange()
 	}
 
 	const _toggleGuestAccess = () => {
@@ -86,12 +88,8 @@ app.controller('WidgetSettingsController', function(
 		}
 
 		$scope.attemptsSliderValue = $scope.UNLIMITED_SLIDER_VALUE
-		$timeout(() => {
-			$('.selector').slider({
-				value: $scope.attemptsSliderValue * 1000,
-				disabled: $scope.guestAccess
-			})
-		})
+
+		_updateSliderAfterChange()
 	}
 
 	const _toggleEmbeddedOnly = () => {
@@ -101,6 +99,20 @@ app.controller('WidgetSettingsController', function(
 		if ($scope.embeddedOnly) {
 			$scope.guestAccess = false
 		}
+
+		_updateSliderAfterChange()
+	}
+
+	// this probably shouldn't have to be used
+	// because the toggles above should be just one
+	// function lilke _setAccess()
+	const _updateSliderAfterChange = () => {
+		$timeout(() => {
+			$('.selector').slider({
+				value: $scope.attemptsSliderValue * 1000,
+				disabled: $scope.guestAccess
+			})
+		})
 	}
 
 	// Fills in the dates from the selected widget

--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -71,8 +71,8 @@ app.service('widgetSrv', function(selectedWidgetSrv, dateTimeServ, $q, $rootScop
 		return Materia.Coms.Json.send('widgets_get_by_type', [type])
 	}
 
-	const copyWidget = (inst_id, newName) => {
-		return Materia.Coms.Json.send('widget_instance_copy', [inst_id, newName])
+	const copyWidget = (inst_id, newName, retainAccess = false) => {
+		return Materia.Coms.Json.send('widget_instance_copy', [inst_id, newName, retainAccess])
 	}
 
 	const deleteWidget = inst_id => {


### PR DESCRIPTION
To be paired with https://github.com/ucfopen/Materia/pull/1290
Additional notes and screenshots are on that pull request

- Added "retain ownership" checkbox to copy modal with clarifying wording
- Added clarifying information at the top of the Settings modal when viewed as a student
- Fixed wonky and unintuitive behavior with access level toggles
- Improved visibility and clarity of disabled access level toggles when a widget is student-made
- Ensured student access removal alert will display regardless of which access toggles are selected or deselected

Some changes still WIP