### PR TITLE
enable previewing and embed together

### DIFF
--- a/src/css/partials/_lti_embed_preview.scss
+++ b/src/css/partials/_lti_embed_preview.scss
@@ -1,0 +1,51 @@
+.preview {
+	header {
+		visibility: visible;
+	}
+	header h1 {
+		background: #68d053;
+	}
+
+	.container {
+		background: #ebebeb;
+		width: 500px;
+		margin: 0 auto;
+		text-align: center;
+		margin-top: 3em;
+		padding: 2em;
+		box-sizing: border-box;
+		position: relative;
+
+		h2 {
+			margin-top: 0;
+		}
+
+		p {
+			margin-bottom: 2em;
+		}
+
+		.button {
+		}
+
+		.widget_info {
+			display: flex;
+			align-items: center;
+			align-content: stretch;
+			position: relative;
+			width: 100%;
+			justify-content: center;
+			margin-top: -20px;
+
+			.widget_icon {
+				flex: 0 1 auto;
+				margin: 10px;
+			}
+
+			.widget_name {
+				flex: 0 1 auto;
+				font-size: 1.2em;
+				text-align: left;
+			}
+		}
+	}
+}

--- a/src/css/util-lti-picker.scss
+++ b/src/css/util-lti-picker.scss
@@ -1,3 +1,6 @@
+// included here for now, should seprate in the future
+@import 'partials/lti_embed_preview';
+
 html {
 	background: white;
 	width: 100%;
@@ -18,28 +21,6 @@ header {
 	height: auto;
 	z-index: 0;
 	visibility: hidden;
-}
-
-.preview header {
-	visibility: visible;
-}
-.preview header h1 {
-	background: #68d053;
-}
-
-.preview .container {
-	background: #ebebeb;
-	width: 500px;
-	height: 300px;
-	margin: 0 auto;
-	text-align: center;
-	margin-top: 5em;
-	padding: 2em;
-	box-sizing: border-box;
-}
-
-.preview .container p {
-	margin-bottom: 2em;
 }
 
 .help-container {

--- a/src/js/controllers/ctrl-lti-resource-selection.js
+++ b/src/js/controllers/ctrl-lti-resource-selection.js
@@ -80,9 +80,13 @@ app.controller('LTIResourceSelectionCtrl', function (
 		$timeout(() => {
 			announceChoice()
 
+			// RETURN_URL is sent from the Tool Consumer at the time of LTI Launch
+			// provided by launch_presentation_return_url or content_item_return_url
+			// if RETURN_URL is set, we'll use it to inform the LTI Tool consumer of our choice
 			if (typeof RETURN_URL !== 'undefined' && RETURN_URL !== null) {
+				const separator = RETURN_URL.includes('?') ? '&' : '?' // append to pre-existing url params?
 				window.location =
-					RETURN_URL + '?embed_type=basic_lti&url=' + encodeURI(selectedWidget.embed_url)
+					RETURN_URL + separator + 'embed_type=basic_lti&url=' + encodeURI(selectedWidget.embed_url)
 			}
 		}, 1000)
 	}

--- a/src/js/controllers/ctrl-score-page.js
+++ b/src/js/controllers/ctrl-score-page.js
@@ -9,13 +9,10 @@ app.controller('ScorePageController', function (Please, $scope, $q, $timeout, Wi
 	let currentAttempt = null
 	let widgetInstance = null
 	let attemptsLeft = 0
-	let single_id = window.location.hash.split('single-')[1]
 
 	// get the play_id from the url if using /scores/single/:play_id/:inst_id url
-	if (!single_id) {
-		const res = window.location.pathname.match(/\/scores\/single\/([a-z0-9\-_]+)/i)
-		single_id = (res && res[1]) || null
-	}
+	const res = window.location.pathname.match(/\/scores\/single\/([a-z0-9\-_]+)/i)
+	let single_id = (res && res[1]) || null
 
 	// @TODO @IE8 This method of checking for isEmbedded is hacky, but
 	// IE8 didn't like "window.self == window.top" (which also might be

--- a/src/js/controllers/ctrl-score-page.js
+++ b/src/js/controllers/ctrl-score-page.js
@@ -15,8 +15,9 @@ app.controller('ScorePageController', function (Please, $scope, $q, $timeout, Wi
 	// problematic with weird plugins that put the page in an iframe).
 	// This should work pretty well but if we ever decide to change the
 	// scores embed URL this will need to be modified!
-	let isEmbedded = window.location.href.toLowerCase().indexOf('/scores/embed/') !== -1
-	let isPreview = /\/preview\//i.test(document.URL)
+	let isEmbedded = /embed\//i.test(document.URL) // /preview-embed/xxx and /embed/xxxx
+	let isPreview = /\/preview/i.test(document.URL) // /preview/xxx and /preview-embed/xxxx
+	console.log(isEmbedded, isPreview, 'isembed, is preview?')
 	let _graphData = []
 
 	// We don't want users who click the 'View more details' link via an LTI to play again, since at that point
@@ -217,14 +218,10 @@ app.controller('ScorePageController', function (Please, $scope, $q, $timeout, Wi
 		// show play again button?
 		if (!single_id && (widgetInstance.attempts <= 0 || parseInt(attemptsLeft) > 0 || isPreview)) {
 			const prefix = (() => {
-				switch (false) {
-					case !isEmbedded:
-						return '/embed/'
-					case !isPreview:
-						return '/preview/'
-					default:
-						return '/play/'
-				}
+				if (isEmbedded && isPreview) return '/preview-embed/'
+				if (isEmbedded) return '/embed/'
+				if (isPreview) return '/preview/'
+				return '/play/'
 			})()
 
 			widget.href = prefix + widgetInstance.id + '/' + widgetInstance.clean_name

--- a/src/js/controllers/ctrl-score-page.js
+++ b/src/js/controllers/ctrl-score-page.js
@@ -10,6 +10,13 @@ app.controller('ScorePageController', function (Please, $scope, $q, $timeout, Wi
 	let widgetInstance = null
 	let attemptsLeft = 0
 	let single_id = window.location.hash.split('single-')[1]
+
+	// get the play_id from the url if using /scores/single/:play_id/:inst_id url
+	if (!single_id) {
+		const res = window.location.pathname.match(/\/scores\/single\/([a-z0-9\-_]+)/i)
+		single_id = (res && res[1]) || null
+	}
+
 	// @TODO @IE8 This method of checking for isEmbedded is hacky, but
 	// IE8 didn't like "window.self == window.top" (which also might be
 	// problematic with weird plugins that put the page in an iframe).

--- a/src/js/controllers/ctrl-widget-player.js
+++ b/src/js/controllers/ctrl-widget-player.js
@@ -540,13 +540,14 @@ app.controller('WidgetPlayerCtrl', function (
 
 	const _showScoreScreen = () => {
 		if (!scoreScreenURL) {
-			if ($scope.isPreview) {
-				scoreScreenURL = `${BASE_URL}scores/preview/${$scope.inst_id}`
-			} else if ($scope.isEmbedded) {
-				scoreScreenURL = `${BASE_URL}scores/embed/${$scope.inst_id}#play-${play_id}`
-			} else {
-				scoreScreenURL = `${BASE_URL}scores/${$scope.inst_id}#play-${play_id}`
-			}
+			const { isEmbedded, isPreview, inst_id } = $scope
+			let path = 'scores/'
+			if (isEmbedded && isPreview) path = 'scores/preview-embed/'
+			else if (isEmbedded) path = 'scores/embed/'
+			else if (isPreview) path = 'scores/preview/'
+
+			let hash = $scope.isPreview ? '' : `#play-${play_id}`
+			scoreScreenURL = `${BASE_URL}${path}${$scope.inst_id}${hash}`
 		}
 
 		if (!$scope.alert.fatal) {

--- a/src/js/controllers/ctrl-widget-player.test.js
+++ b/src/js/controllers/ctrl-widget-player.test.js
@@ -602,6 +602,38 @@ describe('WidgetPlayerCtrl', () => {
 			mockGetEl,
 		} = setupDomStuff()
 
+		$scope.isPreview = false
+		$scope.isEmbedded = true // make sure preview prevails over isEmbedded
+
+		mockSendPromiseOnce()
+		jest.spyOn($location, 'replace')
+
+		mockPostMessage(buildPostMessage('start', ''))
+		mockPostMessage(buildPostMessage('end'))
+
+		_scope.$digest() // make sure defer from post message completes
+
+		expect(window.location.assign).toHaveBeenCalledWith(
+			'https://test_base_url.com/scores/embed/bb8#play-ff88gg'
+		)
+	})
+
+	it('end redirects to preview embed url', () => {
+		let {
+			$scope,
+			controller,
+			mockCreateElement,
+			mockPostMessageFromWidget,
+			mockPostMessage,
+			mockHref,
+			embedStyle,
+			previewStyle,
+			widgetStyle,
+			centerStyle,
+			widgetInstance,
+			mockGetEl,
+		} = setupDomStuff()
+
 		$scope.isPreview = true
 		$scope.isEmbedded = true // make sure preview prevails over isEmbedded
 
@@ -614,7 +646,7 @@ describe('WidgetPlayerCtrl', () => {
 		_scope.$digest() // make sure defer from post message completes
 
 		expect(window.location.assign).toHaveBeenCalledWith(
-			'https://test_base_url.com/scores/preview/bb8'
+			'https://test_base_url.com/scores/preview-embed/bb8'
 		)
 	})
 

--- a/src/js/directives/dir-scoretable.js
+++ b/src/js/directives/dir-scoretable.js
@@ -62,8 +62,8 @@ app.directive('scoreTable', function (SelectedWidgetSrv, $window) {
 				$scope.selectedUser = $scope.users[id]
 			}
 
-			$scope.showScorePage = function (scoreId) {
-				$window.open(`${BASE_URL}scores/${widgetId}/#single-${scoreId}`)
+			$scope.showScorePage = function (playId) {
+				$window.open(`${BASE_URL}scores/single/${playId}/${widgetId}`)
 				return true
 			}
 

--- a/src/js/directives/dir-scoretable.test.js
+++ b/src/js/directives/dir-scoretable.test.js
@@ -81,7 +81,7 @@ describe('scoreTable Directive', function () {
 		$window.open = jest.fn()
 		global.BASE_URL = 'some_url'
 		$scope.showScorePage('two')
-		expect($window.open).toHaveBeenLastCalledWith('some_urlscores/6/#single-two')
+		expect($window.open).toHaveBeenLastCalledWith('some_urlscores/single/two/6')
 	})
 
 	it('searchStudentActivity locates users', function () {


### PR DESCRIPTION
* updates styles of embedded lti preview page
* requires materia server changes on https://github.com/ucfopen/Materia/pull/1300
* removes support for older `/scores/:inst_id/#single-:play_id` urls, migrated to `scores/single/:play_id/:inst_id` 