### PR TITLE
lti picker handles query params in return url

### DIFF
--- a/src/js/controllers/ctrl-lti-resource-selection.js
+++ b/src/js/controllers/ctrl-lti-resource-selection.js
@@ -81,8 +81,12 @@ app.controller('LTIResourceSelectionCtrl', function (
 			announceChoice()
 
 			if (typeof RETURN_URL !== 'undefined' && RETURN_URL !== null) {
-				window.location =
-					RETURN_URL + '?embed_type=basic_lti&url=' + encodeURI(selectedWidget.embed_url)
+				// add a ? or & depending on RETURN_URL already containing query params
+				const seperator = RETURN_URL.includes('?') ? '&' : '?'
+				// endode the url
+				const url = encodeURI(selectedWidget.embed_url)
+				// redirect the client to the return url with our new variables
+				window.location = `${RETURN_URL}${seperator}embed_type=basic_lti&url=${url}`
 			}
 		}, 1000)
 	}

--- a/src/js/controllers/ctrl-lti-resource-selection.js
+++ b/src/js/controllers/ctrl-lti-resource-selection.js
@@ -84,7 +84,6 @@ app.controller('LTIResourceSelectionCtrl', function (
 			// provided by launch_presentation_return_url or content_item_return_url
 			// if RETURN_URL is set, we'll use it to inform the LTI Tool consumer of our choice
 			if (typeof RETURN_URL !== 'undefined' && RETURN_URL !== null) {
-
 				// add a ? or & depending on RETURN_URL already containing query params
 				const seperator = RETURN_URL.includes('?') ? '&' : '?'
 				// endode the url


### PR DESCRIPTION
Allows lti resource selection return url to handle query params given by the LMS.

Previously, If the picker was launched with with a `launch_presentation_return_url` that contained query params, materia incorrectly assumed there were none and simply appended a `?var=value` to the return url.

Now, the code will detect if it needs to append a question mark or an ampersand. 