### PR TITLE
Prevent users from seeing widgets in My Widgets that they don't have access to.

### DIFF
--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -244,7 +244,15 @@ app.service('WidgetSrv', function (SelectedWidgetSrv, DateTimeServ, $q, $rootSco
 			if (selID.substr(0, 1) === '/') {
 				selID = selID.substr(1)
 			}
-			getWidget(selID)
+			Materia.Coms.Json.send('widget_instance_access_perms_verify', [[selID]])
+				.then((status) => {
+					if (!status) {
+						throw new Error('You do not have permission to see this widget!')
+					}
+				})
+				.then(() => {
+					return getWidget(selID)
+				})
 				.then((widget) => {
 					SelectedWidgetSrv.set(widget)
 				})

--- a/src/js/services/srv-widget.test.js
+++ b/src/js/services/srv-widget.test.js
@@ -379,6 +379,8 @@ describe('WidgetSrv', () => {
 	})
 
 	it('selectWidgetFromHashUrl loads widget and sets selection', () => {
+		// have to pretend the API verifies that this user can see this widget
+		mockSendPromiseOnce(true)
 		mockHashGet.mockImplementation(() => '/0UNM0')
 		mockSendPromiseOnce(getMockApiData('widget_instances_get'))
 		_service.selectWidgetFromHashUrl()
@@ -386,6 +388,18 @@ describe('WidgetSrv', () => {
 
 		expect(_SelectedWidgetSrv.set).toHaveBeenCalled()
 		expect(_SelectedWidgetSrv.set.mock.calls[0][0].id).toBe('0UNM0')
+	})
+
+	it('selectWidgetFromHashUrl does not load widget when user lacks access', () => {
+		// have to pretend the API verifies that this user can see this widget
+		mockSendPromiseOnce(false)
+		mockHashGet.mockImplementation(() => '/0UNM0')
+		mockSendPromiseOnce(getMockApiData('widget_instances_get'))
+		_service.selectWidgetFromHashUrl()
+		$scope.$digest() // processes promise
+
+		expect(_SelectedWidgetSrv.set).not.toHaveBeenCalled()
+		// expect(_SelectedWidgetSrv.set.mock.calls[0][0].id).toBe('0UNM0')
 	})
 
 	it('selectWidgetFromHashUrl warns about not having access', () => {


### PR DESCRIPTION
Adds a call to a new API endpoint that confirms a user has the permissions necessary to see a widget in the My Widgets page.