### PR TITLE
Add content item and picker launches to lti/assignment for Sakai compatability

### DIFF
--- a/src/js/services/srv-widget.js
+++ b/src/js/services/srv-widget.js
@@ -7,6 +7,14 @@ app.service('WidgetSrv', function (SelectedWidgetSrv, DateTimeServ, $q, $rootSco
 
 	const sortWidgets = () => _widgets.sort((a, b) => b.created_at - a.created_at)
 
+	const signLtiContentItemSelection = (url, params, ltiKey) => {
+		const deferred = $q.defer()
+		Materia.Coms.Json.send('lti_sign_content_item_selection', [url, params, ltiKey]).then((results) => {
+			deferred.resolve(results)
+		})
+		return deferred.promise
+	}
+
 	const getWidgets = (force = false) => {
 		const deferred = $q.defer()
 
@@ -286,5 +294,6 @@ app.service('WidgetSrv', function (SelectedWidgetSrv, DateTimeServ, $q, $rootSco
 		copyWidget,
 		deleteWidget,
 		canBePublishedByCurrentUser,
+		signLtiContentItemSelection,
 	}
 })


### PR DESCRIPTION
Adds support for Sakai ContentItemSelectionRequest by responding with a signed ContentItem post. 

Requires https://github.com/ucfopen/Materia/pull/1428 (see that pr as it contains most of the changes)

